### PR TITLE
Normalize Guardian config fields and add regression test

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,7 @@ require('dotenv').config({ path: path.join(process.cwd(), '.guardian', '.env') }
 const GuardianEngine = require('./guardian-engine');
 const AIAssistant = require('./ai-assistant');
 const setup = require('./setup');
+const { readConfig } = require('./lib/config-utils');
 
 program
     .name('nimbus')
@@ -598,13 +599,7 @@ program
 // Helper functions
 
 async function loadConfig() {
-    const configPath = path.join(process.cwd(), '.guardian', 'config.json');
-
-    try {
-        return await fs.readJson(configPath);
-    } catch {
-        return null;
-    }
+    return await readConfig(process.cwd());
 }
 
 function displayResults(results, experienceLevel) {

--- a/dashboard-server.js
+++ b/dashboard-server.js
@@ -15,6 +15,7 @@ const { execSync } = require('child_process');
 const GuardianEngine = require('./guardian-engine');
 const ToolDetector = require('./tool-detector');
 const AIAssistant = require('./ai-assistant');
+const { readConfig } = require('./lib/config-utils');
 
 class DashboardServer {
     constructor(port = 3333) {
@@ -46,16 +47,20 @@ class DashboardServer {
     }
 
     async loadConfig() {
-        const configPath = path.join(this.projectPath, '.guardian', 'config.json');
-        try {
-            this.config = await fs.readJson(configPath);
-            require('dotenv').config({ path: path.join(this.projectPath, '.guardian', '.env') });
-        } catch {
+        const config = await readConfig(this.projectPath);
+
+        if (config) {
+            this.config = config;
+        } else {
             this.config = {
                 projectName: path.basename(this.projectPath),
-                experienceLevel: 'intermediate'
+                experienceLevel: 'intermediate',
+                preferredProvider: 'claude',
+                platform: 'Unknown'
             };
         }
+
+        require('dotenv').config({ path: path.join(this.projectPath, '.guardian', '.env') });
     }
 
     async handleRequest(req, res) {

--- a/lib/config-utils.js
+++ b/lib/config-utils.js
@@ -1,0 +1,56 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+function normalizeConfig(config = {}) {
+    if (!config) return null;
+
+    const normalized = { ...config };
+
+    if (!normalized.experienceLevel && normalized.experience) {
+        normalized.experienceLevel = normalized.experience;
+    }
+    if (!normalized.preferredProvider && normalized.aiProvider) {
+        normalized.preferredProvider = normalized.aiProvider;
+    }
+    if (!normalized.platform && normalized.cloudProvider) {
+        normalized.platform = normalized.cloudProvider;
+    }
+
+    if (!normalized.experienceLevel && process.env.EXPERIENCE_LEVEL) {
+        normalized.experienceLevel = process.env.EXPERIENCE_LEVEL;
+    }
+    if (!normalized.preferredProvider && (process.env.PREFERRED_PROVIDER || process.env.AI_PROVIDER)) {
+        normalized.preferredProvider = process.env.PREFERRED_PROVIDER || process.env.AI_PROVIDER;
+    }
+    if (!normalized.platform && (process.env.PLATFORM || process.env.CLOUD_PROVIDER)) {
+        normalized.platform = process.env.PLATFORM || process.env.CLOUD_PROVIDER;
+    }
+
+    if (normalized.experienceLevel && !normalized.experience) {
+        normalized.experience = normalized.experienceLevel;
+    }
+    if (normalized.preferredProvider && !normalized.aiProvider) {
+        normalized.aiProvider = normalized.preferredProvider;
+    }
+    if (normalized.platform && !normalized.cloudProvider) {
+        normalized.cloudProvider = normalized.platform;
+    }
+
+    return normalized;
+}
+
+async function readConfig(projectPath) {
+    const configPath = path.join(projectPath, '.guardian', 'config.json');
+
+    try {
+        const config = await fs.readJson(configPath);
+        return normalizeConfig(config);
+    } catch {
+        return null;
+    }
+}
+
+module.exports = {
+    normalizeConfig,
+    readConfig
+};

--- a/setup.js
+++ b/setup.js
@@ -12,6 +12,23 @@ const path = require('path');
 const chalk = require('chalk');
 const boxen = require('boxen');
 
+function createConfigFromAnswers(answers) {
+    const config = {
+        projectName: answers.projectName,
+        experienceLevel: answers.experience,
+        preferredProvider: answers.aiProvider,
+        platform: answers.cloudProvider,
+        setupDate: new Date().toISOString()
+    };
+
+    // Legacy fields for backward compatibility with older versions
+    config.experience = config.experienceLevel;
+    config.aiProvider = config.preferredProvider;
+    config.cloudProvider = config.platform;
+
+    return config;
+}
+
 async function setup() {
     console.clear();
 
@@ -101,13 +118,7 @@ async function setup() {
     }
 
     // Create configuration
-    const config = {
-        projectName: answers.projectName,
-        experience: answers.experience,
-        cloudProvider: answers.cloudProvider,
-        aiProvider: answers.aiProvider,
-        setupDate: new Date().toISOString()
-    };
+    const config = createConfigFromAnswers(answers);
 
     const configDir = path.join(process.cwd(), '.guardian');
     await fs.ensureDir(configDir);
@@ -123,6 +134,8 @@ ${answers.geminiApiKey ? `GEMINI_API_KEY=${answers.geminiApiKey}` : '# GEMINI_AP
 # Project Configuration
 PROJECT_NAME=${answers.projectName}
 EXPERIENCE_LEVEL=${answers.experience}
+PREFERRED_PROVIDER=${answers.aiProvider}
+PLATFORM=${answers.cloudProvider}
 `;
 
     await fs.writeFile(path.join(configDir, '.env'), envContent);
@@ -320,3 +333,4 @@ if (require.main === module) {
 }
 
 module.exports = setup;
+module.exports.createConfigFromAnswers = createConfigFromAnswers;

--- a/test-config-regression.js
+++ b/test-config-regression.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+
+const GuardianEngine = require('./guardian-engine');
+const setup = require('./setup');
+const { readConfig } = require('./lib/config-utils');
+
+async function run() {
+    const answers = {
+        projectName: 'regression-project',
+        experience: 'advanced',
+        cloudProvider: 'Google Cloud (Firebase)',
+        aiProvider: 'claude'
+    };
+
+    // Case 1: Fresh config produced by setup helper
+    const freshDir = await fs.mkdtemp(path.join(os.tmpdir(), 'guardian-config-fresh-'));
+    const freshConfigDir = path.join(freshDir, '.guardian');
+    await fs.ensureDir(freshConfigDir);
+
+    const freshConfig = setup.createConfigFromAnswers(answers);
+    await fs.writeJson(path.join(freshConfigDir, 'config.json'), freshConfig, { spaces: 2 });
+
+    const normalizedFresh = await readConfig(freshDir);
+    assert.ok(normalizedFresh, 'Fresh config should load');
+    assert.strictEqual(normalizedFresh.experienceLevel, answers.experience, 'experienceLevel should match wizard answer');
+    assert.strictEqual(normalizedFresh.preferredProvider, answers.aiProvider, 'preferredProvider should match wizard answer');
+    assert.strictEqual(normalizedFresh.platform, answers.cloudProvider, 'platform should match wizard answer');
+
+    const engineFromFresh = new GuardianEngine(freshDir, normalizedFresh);
+    assert.strictEqual(engineFromFresh.config.experienceLevel, answers.experience, 'GuardianEngine config should include experienceLevel');
+    assert.strictEqual(engineFromFresh.ai.config.preferredProvider, answers.aiProvider, 'GuardianEngine AI should honor preferred provider');
+
+    // Case 2: Legacy config missing the new keys
+    const legacyDir = await fs.mkdtemp(path.join(os.tmpdir(), 'guardian-config-legacy-'));
+    const legacyConfigDir = path.join(legacyDir, '.guardian');
+    await fs.ensureDir(legacyConfigDir);
+
+    const legacyConfig = { ...freshConfig };
+    delete legacyConfig.experienceLevel;
+    delete legacyConfig.preferredProvider;
+    delete legacyConfig.platform;
+    await fs.writeJson(path.join(legacyConfigDir, 'config.json'), legacyConfig, { spaces: 2 });
+
+    const normalizedLegacy = await readConfig(legacyDir);
+    assert.ok(normalizedLegacy, 'Legacy config should load');
+    assert.strictEqual(normalizedLegacy.experienceLevel, answers.experience, 'Legacy config should normalize experienceLevel');
+    assert.strictEqual(normalizedLegacy.preferredProvider, answers.aiProvider, 'Legacy config should normalize preferredProvider');
+    assert.strictEqual(normalizedLegacy.platform, answers.cloudProvider, 'Legacy config should normalize platform');
+
+    const engineFromLegacy = new GuardianEngine(legacyDir, normalizedLegacy);
+    assert.strictEqual(engineFromLegacy.config.experienceLevel, answers.experience, 'GuardianEngine should normalize legacy experience');
+    assert.strictEqual(engineFromLegacy.ai.config.preferredProvider, answers.aiProvider, 'GuardianEngine should normalize legacy preferred provider');
+
+    await fs.remove(freshDir);
+    await fs.remove(legacyDir);
+
+    console.log('✅ GuardianEngine respects config from setup and legacy files');
+}
+
+run().catch(error => {
+    console.error('❌ Guardian config regression failed');
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- update the setup wizard to emit the new config keys and synced environment variables while keeping legacy fields for backwards compatibility
- introduce shared config utilities so the CLI and dashboard normalize legacy config files transparently
- add a regression test that exercises GuardianEngine with setup-produced and legacy configs to ensure the preferred provider and experience level propagate

## Testing
- node test-config-regression.js

------
https://chatgpt.com/codex/tasks/task_e_68e3070022148329bd8e4f43ebd1942b