### PR TITLE
Strengthen Guardian config normalization and regression tests

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,6 +18,7 @@ require('dotenv').config({ path: path.join(process.cwd(), '.guardian', '.env') }
 const GuardianEngine = require('./guardian-engine');
 const AIAssistant = require('./ai-assistant');
 const setup = require('./setup');
+const { readConfig } = require('./lib/config-utils');
 
 program
     .name('nimbus')
@@ -598,13 +599,7 @@ program
 // Helper functions
 
 async function loadConfig() {
-    const configPath = path.join(process.cwd(), '.guardian', 'config.json');
-
-    try {
-        return await fs.readJson(configPath);
-    } catch {
-        return null;
-    }
+    return await readConfig(process.cwd());
 }
 
 function displayResults(results, experienceLevel) {

--- a/dashboard-server.js
+++ b/dashboard-server.js
@@ -15,6 +15,7 @@ const { execSync } = require('child_process');
 const GuardianEngine = require('./guardian-engine');
 const ToolDetector = require('./tool-detector');
 const AIAssistant = require('./ai-assistant');
+const { readConfig } = require('./lib/config-utils');
 
 class DashboardServer {
     constructor(port = 3333) {
@@ -46,16 +47,20 @@ class DashboardServer {
     }
 
     async loadConfig() {
-        const configPath = path.join(this.projectPath, '.guardian', 'config.json');
-        try {
-            this.config = await fs.readJson(configPath);
-            require('dotenv').config({ path: path.join(this.projectPath, '.guardian', '.env') });
-        } catch {
+        const config = await readConfig(this.projectPath);
+
+        if (config) {
+            this.config = config;
+        } else {
             this.config = {
                 projectName: path.basename(this.projectPath),
-                experienceLevel: 'intermediate'
+                experienceLevel: 'intermediate',
+                preferredProvider: 'claude',
+                platform: 'Unknown'
             };
         }
+
+        require('dotenv').config({ path: path.join(this.projectPath, '.guardian', '.env') });
     }
 
     async handleRequest(req, res) {

--- a/lib/config-utils.js
+++ b/lib/config-utils.js
@@ -1,0 +1,78 @@
+const fs = require('fs-extra');
+const path = require('path');
+const dotenv = require('dotenv');
+
+function normalizeConfig(config = {}) {
+    const normalized = { ...(config || {}) };
+
+    if (!normalized.experienceLevel && normalized.experience) {
+        normalized.experienceLevel = normalized.experience;
+    }
+    if (!normalized.preferredProvider && normalized.aiProvider) {
+        normalized.preferredProvider = normalized.aiProvider;
+    }
+    if (!normalized.platform && normalized.cloudProvider) {
+        normalized.platform = normalized.cloudProvider;
+    }
+
+    if (!normalized.projectName && process.env.PROJECT_NAME) {
+        normalized.projectName = process.env.PROJECT_NAME;
+    }
+    if (!normalized.experienceLevel && process.env.EXPERIENCE_LEVEL) {
+        normalized.experienceLevel = process.env.EXPERIENCE_LEVEL;
+    }
+    if (!normalized.preferredProvider && (process.env.PREFERRED_PROVIDER || process.env.AI_PROVIDER)) {
+        normalized.preferredProvider = process.env.PREFERRED_PROVIDER || process.env.AI_PROVIDER;
+    }
+    if (!normalized.platform && (process.env.PLATFORM || process.env.CLOUD_PROVIDER)) {
+        normalized.platform = process.env.PLATFORM || process.env.CLOUD_PROVIDER;
+    }
+    if (!normalized.claudeApiKey && process.env.CLAUDE_API_KEY) {
+        normalized.claudeApiKey = process.env.CLAUDE_API_KEY;
+    }
+    if (!normalized.geminiApiKey && process.env.GEMINI_API_KEY) {
+        normalized.geminiApiKey = process.env.GEMINI_API_KEY;
+    }
+
+    if (normalized.experienceLevel && !normalized.experience) {
+        normalized.experience = normalized.experienceLevel;
+    }
+    if (normalized.preferredProvider && !normalized.aiProvider) {
+        normalized.aiProvider = normalized.preferredProvider;
+    }
+    if (normalized.platform && !normalized.cloudProvider) {
+        normalized.cloudProvider = normalized.platform;
+    }
+
+    return Object.keys(normalized).length > 0 ? normalized : null;
+}
+
+async function readConfig(projectPath) {
+    await loadGuardianEnv(projectPath);
+
+    const configPath = path.join(projectPath, '.guardian', 'config.json');
+
+    try {
+        const config = await fs.readJson(configPath);
+        return normalizeConfig(config);
+    } catch {
+        return normalizeConfig({});
+    }
+}
+
+async function loadGuardianEnv(projectPath) {
+    const envPath = path.join(projectPath, '.guardian', '.env');
+
+    try {
+        if (await fs.pathExists(envPath)) {
+            dotenv.config({ path: envPath, override: true });
+        }
+    } catch {
+        // Ignore env loading errors - config reading should continue
+    }
+}
+
+module.exports = {
+    normalizeConfig,
+    readConfig
+};

--- a/setup.js
+++ b/setup.js
@@ -12,6 +12,23 @@ const path = require('path');
 const chalk = require('chalk');
 const boxen = require('boxen');
 
+function createConfigFromAnswers(answers) {
+    const config = {
+        projectName: answers.projectName,
+        experienceLevel: answers.experience,
+        preferredProvider: answers.aiProvider,
+        platform: answers.cloudProvider,
+        setupDate: new Date().toISOString()
+    };
+
+    // Legacy fields for backward compatibility with older versions
+    config.experience = config.experienceLevel;
+    config.aiProvider = config.preferredProvider;
+    config.cloudProvider = config.platform;
+
+    return config;
+}
+
 async function setup() {
     console.clear();
 
@@ -101,13 +118,7 @@ async function setup() {
     }
 
     // Create configuration
-    const config = {
-        projectName: answers.projectName,
-        experience: answers.experience,
-        cloudProvider: answers.cloudProvider,
-        aiProvider: answers.aiProvider,
-        setupDate: new Date().toISOString()
-    };
+    const config = createConfigFromAnswers(answers);
 
     const configDir = path.join(process.cwd(), '.guardian');
     await fs.ensureDir(configDir);
@@ -123,6 +134,12 @@ ${answers.geminiApiKey ? `GEMINI_API_KEY=${answers.geminiApiKey}` : '# GEMINI_AP
 # Project Configuration
 PROJECT_NAME=${answers.projectName}
 EXPERIENCE_LEVEL=${answers.experience}
+PREFERRED_PROVIDER=${answers.aiProvider}
+PLATFORM=${answers.cloudProvider}
+
+# Legacy compatibility
+AI_PROVIDER=${answers.aiProvider}
+CLOUD_PROVIDER=${answers.cloudProvider}
 `;
 
     await fs.writeFile(path.join(configDir, '.env'), envContent);
@@ -320,3 +337,4 @@ if (require.main === module) {
 }
 
 module.exports = setup;
+module.exports.createConfigFromAnswers = createConfigFromAnswers;

--- a/test-config-regression.js
+++ b/test-config-regression.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+
+const GuardianEngine = require('./guardian-engine');
+const setup = require('./setup');
+const { readConfig } = require('./lib/config-utils');
+
+const ENV_KEYS = [
+    'PROJECT_NAME',
+    'EXPERIENCE_LEVEL',
+    'PREFERRED_PROVIDER',
+    'AI_PROVIDER',
+    'PLATFORM',
+    'CLOUD_PROVIDER',
+    'CLAUDE_API_KEY',
+    'GEMINI_API_KEY'
+];
+
+function snapshotEnv(keys) {
+    return keys.reduce((acc, key) => {
+        if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+            acc[key] = process.env[key];
+        } else {
+            acc[key] = undefined;
+        }
+        return acc;
+    }, {});
+}
+
+function restoreEnv(snapshot) {
+    for (const [key, value] of Object.entries(snapshot)) {
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
+    }
+}
+
+async function run() {
+    const originalEnv = snapshotEnv(ENV_KEYS);
+
+    const answers = {
+        projectName: 'regression-project',
+        experience: 'advanced',
+        cloudProvider: 'Google Cloud (Firebase)',
+        aiProvider: 'claude'
+    };
+
+    try {
+        // Case 1: Fresh config produced by setup helper
+        const freshDir = await fs.mkdtemp(path.join(os.tmpdir(), 'guardian-config-fresh-'));
+        const freshConfigDir = path.join(freshDir, '.guardian');
+        await fs.ensureDir(freshConfigDir);
+
+        const freshConfig = setup.createConfigFromAnswers(answers);
+        await fs.writeJson(path.join(freshConfigDir, 'config.json'), freshConfig, { spaces: 2 });
+
+        const normalizedFresh = await readConfig(freshDir);
+        assert.ok(normalizedFresh, 'Fresh config should load');
+        assert.strictEqual(normalizedFresh.experienceLevel, answers.experience, 'experienceLevel should match wizard answer');
+        assert.strictEqual(normalizedFresh.preferredProvider, answers.aiProvider, 'preferredProvider should match wizard answer');
+        assert.strictEqual(normalizedFresh.platform, answers.cloudProvider, 'platform should match wizard answer');
+
+        const engineFromFresh = new GuardianEngine(freshDir, normalizedFresh);
+        assert.strictEqual(engineFromFresh.config.experienceLevel, answers.experience, 'GuardianEngine config should include experienceLevel');
+        assert.strictEqual(engineFromFresh.ai.config.preferredProvider, answers.aiProvider, 'GuardianEngine AI should honor preferred provider');
+
+        // Case 2: Legacy config missing the new keys
+        const legacyDir = await fs.mkdtemp(path.join(os.tmpdir(), 'guardian-config-legacy-'));
+        const legacyConfigDir = path.join(legacyDir, '.guardian');
+        await fs.ensureDir(legacyConfigDir);
+
+        const legacyConfig = { ...freshConfig };
+        delete legacyConfig.experienceLevel;
+        delete legacyConfig.preferredProvider;
+        delete legacyConfig.platform;
+        await fs.writeJson(path.join(legacyConfigDir, 'config.json'), legacyConfig, { spaces: 2 });
+
+        const normalizedLegacy = await readConfig(legacyDir);
+        assert.ok(normalizedLegacy, 'Legacy config should load');
+        assert.strictEqual(normalizedLegacy.experienceLevel, answers.experience, 'Legacy config should normalize experienceLevel');
+        assert.strictEqual(normalizedLegacy.preferredProvider, answers.aiProvider, 'Legacy config should normalize preferredProvider');
+        assert.strictEqual(normalizedLegacy.platform, answers.cloudProvider, 'Legacy config should normalize platform');
+
+        const engineFromLegacy = new GuardianEngine(legacyDir, normalizedLegacy);
+        assert.strictEqual(engineFromLegacy.config.experienceLevel, answers.experience, 'GuardianEngine should normalize legacy experience');
+        assert.strictEqual(engineFromLegacy.ai.config.preferredProvider, answers.aiProvider, 'GuardianEngine should normalize legacy preferred provider');
+
+        // Case 3: Environment fallback for missing config fields
+        restoreEnv(originalEnv);
+
+        const envDir = await fs.mkdtemp(path.join(os.tmpdir(), 'guardian-config-env-'));
+        const envConfigDir = path.join(envDir, '.guardian');
+        await fs.ensureDir(envConfigDir);
+
+        await fs.writeJson(path.join(envConfigDir, 'config.json'), { projectName: answers.projectName }, { spaces: 2 });
+
+        const envFile = `PROJECT_NAME=${answers.projectName}
+EXPERIENCE_LEVEL=${answers.experience}
+PREFERRED_PROVIDER=${answers.aiProvider}
+PLATFORM=${answers.cloudProvider}
+
+AI_PROVIDER=${answers.aiProvider}
+CLOUD_PROVIDER=${answers.cloudProvider}
+`;
+        await fs.writeFile(path.join(envConfigDir, '.env'), envFile);
+
+        const normalizedEnv = await readConfig(envDir);
+        assert.ok(normalizedEnv, 'Environment-backed config should load');
+        assert.strictEqual(normalizedEnv.projectName, answers.projectName, 'Environment should provide projectName');
+        assert.strictEqual(normalizedEnv.experienceLevel, answers.experience, 'Environment should provide experienceLevel');
+        assert.strictEqual(normalizedEnv.preferredProvider, answers.aiProvider, 'Environment should provide preferredProvider');
+        assert.strictEqual(normalizedEnv.platform, answers.cloudProvider, 'Environment should provide platform');
+
+        const engineFromEnv = new GuardianEngine(envDir, normalizedEnv);
+        assert.strictEqual(engineFromEnv.ai.config.preferredProvider, answers.aiProvider, 'GuardianEngine should honor provider from environment');
+
+        await fs.remove(freshDir);
+        await fs.remove(legacyDir);
+        await fs.remove(envDir);
+
+        console.log('✅ GuardianEngine respects config from setup, legacy files, and environment fallbacks');
+    } finally {
+        restoreEnv(originalEnv);
+    }
+}
+
+run().catch(error => {
+    console.error('❌ Guardian config regression failed');
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- load `.guardian/.env` during config reads and extend normalization so legacy and environment values populate the new config fields
- update the setup wizard's `.env` template to include legacy variable names alongside the new ones for backward compatibility
- expand the regression script to cover environment fallbacks while preserving the caller's process environment

## Testing
- node test-config-regression.js

------
https://chatgpt.com/codex/tasks/task_e_68e3070022148329bd8e4f43ebd1942b