### PR TITLE
Add dashboard API rate limiting and throttle handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Nimbus Guardian environment template
+# Copy this file to .env and populate the values with your own credentials.
+
+# AI assistant providers
+CLAUDE_API_KEY=your-claude-api-key
+GEMINI_API_KEY=your-gemini-api-key
+
+# Optional Firebase project credentials used by the holographic dashboard.
+# You can delete these if you are not using Firebase-backed telemetry.
+FIREBASE_API_KEY=your-firebase-api-key
+FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+FIREBASE_MESSAGING_SENDER_ID=000000000000
+FIREBASE_APP_ID=0:000000000000:web:0000000000000000

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,31 @@
+# Node dependencies
 node_modules/
+
+# Environment files
 .env
+.env.*
+*.env
+!.env.example
 .guardian/.env
+
+# Build outputs
+build/
+dist/
+
+# Logs and diagnostics
 *.log
+logs/
+
+# OS artifacts
 .DS_Store
+
+# Secrets and credentials
+serviceAccountKey.json
+*credentials*.json
+*.pem
+*.key
+
+# Temporary directories
+.test-results/
 test-projects/
 temp/

--- a/ai-assistant.js
+++ b/ai-assistant.js
@@ -179,7 +179,7 @@ Be precise, comprehensive, and assume strong technical foundation.`
             console.error('Claude API error:', error);
 
             if (error.status === 401) {
-                throw new Error('Invalid Claude API key. Run "guardian setup" to update your keys.');
+                throw new Error('Invalid Claude API key. Run "nimbus setup" to update your keys.');
             }
 
             throw new Error(`Claude API error: ${error.message}`);
@@ -215,7 +215,7 @@ Be precise, comprehensive, and assume strong technical foundation.`
             console.error('Gemini API error:', error);
 
             if (error.message.includes('API key')) {
-                throw new Error('Invalid Gemini API key. Run "guardian setup" to update your keys.');
+                throw new Error('Invalid Gemini API key. Run "nimbus setup" to update your keys.');
             }
 
             throw new Error(`Gemini API error: ${error.message}`);

--- a/create-test-admin.js
+++ b/create-test-admin.js
@@ -5,7 +5,24 @@
  * Sets up a temporary admin for testing license generation
  */
 
+const path = require('path');
+const fs = require('fs');
+const dotenv = require('dotenv');
 const admin = require('firebase-admin');
+
+// Hydrate environment variables from project .env files if present
+const envCandidates = [
+    path.join(process.cwd(), '.env'),
+    path.join(process.cwd(), '.guardian', '.env')
+];
+
+for (const candidate of envCandidates) {
+    if (fs.existsSync(candidate)) {
+        dotenv.config({ path: candidate });
+    }
+}
+
+const firebaseWebApiKey = process.env.FIREBASE_API_KEY;
 
 // Initialize with environment variable or default path
 const serviceAccountPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
@@ -85,9 +102,13 @@ async function testLicenseGeneration(customToken) {
     console.log('\n🧪 Testing license generation with admin token...\n');
 
     try {
+        if (!firebaseWebApiKey) {
+            throw new Error('FIREBASE_API_KEY environment variable is required for Firebase Identity Toolkit');
+        }
+
         // Exchange custom token for ID token
         const response = await fetch(
-            `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyCdJO1Y_s-s_phMrTmm6VDQG-pvNEtyPSI`,
+            `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebaseWebApiKey}`,
             {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },

--- a/dashboard-holographic.html
+++ b/dashboard-holographic.html
@@ -3,9 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="csrf-token" content="__CSRF_TOKEN__">
+    <meta name="csp-nonce" content="__CSP_NONCE__">
     <title>Guardian Dashboard - Holographic Interface</title>
+    <script nonce="__CSP_NONCE__">
+        window.__CSRF_TOKEN__ = '__CSRF_TOKEN__';
+        window.__CSP_NONCE__ = '__CSP_NONCE__';
+    </script>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
-    <style>
+    <style nonce="__CSP_NONCE__">
         * {
             margin: 0;
             padding: 0;
@@ -39,6 +45,7 @@
             min-height: 100vh;
             transform-style: preserve-3d;
             transition: transform 0.3s ease-out;
+            transform: rotateY(0deg) rotateX(0deg);
         }
 
         /* DEPTH LAYERS */
@@ -111,6 +118,37 @@
             letter-spacing: 2px;
         }
 
+        .config-warning-banner {
+            margin: 20px auto 0 auto;
+            max-width: 640px;
+            padding: 14px 18px;
+            border-radius: 20px;
+            border: 1px solid rgba(255, 196, 0, 0.6);
+            background: rgba(255, 196, 0, 0.15);
+            color: #ffe59a;
+            font-size: 0.9rem;
+            line-height: 1.6;
+            text-align: left;
+            box-shadow: 0 0 30px rgba(255, 196, 0, 0.25);
+        }
+
+        .config-warning-banner.hidden {
+            display: none;
+        }
+
+        .config-warning-banner strong {
+            display: block;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+            letter-spacing: 1.5px;
+            color: #fff6c2;
+        }
+
+        .config-warning-banner ul {
+            margin: 8px 0 0 20px;
+            padding: 0;
+        }
+
         @keyframes pulse {
             0%, 100% { opacity: 1; }
             50% { opacity: 0.8; }
@@ -125,6 +163,14 @@
             max-width: 1600px;
             margin: 0 auto;
             position: relative;
+        }
+
+        .dashboard-grid--offset {
+            margin-top: 500px;
+        }
+
+        .neo-card--full {
+            grid-column: 1 / -1;
         }
 
         /* NEOSKEUOMORPHIC CARDS */
@@ -266,11 +312,24 @@
             letter-spacing: 1px;
         }
 
+        .metric-detail {
+            display: block;
+            opacity: 0.7;
+        }
+
         .metric-value {
             font-size: 1.1rem;
             font-weight: 700;
             color: var(--holo-cyan);
             text-shadow: 0 0 10px var(--holo-cyan);
+        }
+
+        .section-label {
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            color: rgba(255, 255, 255, 0.5);
+            margin: 12px 0 6px 4px;
         }
 
         /* HOLOGRAPHIC PROGRESS BAR */
@@ -539,6 +598,7 @@
             <div class="guardian-header">
                 <div class="guardian-logo">🛡️ GUARDIAN</div>
                 <div class="project-name" id="project-name">Loading...</div>
+                <div class="config-warning-banner hidden" id="config-warnings"></div>
             </div>
         </div>
 
@@ -593,13 +653,13 @@
 
         <!-- MIDGROUND LAYER - Secondary Info -->
         <div class="depth-layer midground">
-            <div class="dashboard-grid" style="margin-top: 500px;">
+            <div class="dashboard-grid dashboard-grid--offset">
 
                 <!-- Issues Card -->
-                <div class="neo-card" style="grid-column: 1 / -1;" id="issues-card">
+                <div class="neo-card neo-card--full" id="issues-card">
                     <div class="card-header">
                         <div class="card-title">⚠️ Issues</div>
-                        <button class="holo-button" onclick="refreshScan()">Rescan</button>
+                        <button class="holo-button" type="button" data-action="refresh-scan">Rescan</button>
                     </div>
                     <div class="card-body">
                         <ul id="issues-list" class="issue-list loading">
@@ -614,14 +674,69 @@
 
     </div>
 
-    <script>
-        // Parallax effect on mouse move (reduced intensity)
+    <script nonce="__CSP_NONCE__">
         const scene = document.getElementById('scene');
         const mouseXDisplay = document.getElementById('mouseX');
         const mouseYDisplay = document.getElementById('mouseY');
+        const particlesContainer = document.getElementById('particles');
         let isCardHovered = false;
 
-        // Track card hover state
+        const MAX_TILT = 8;
+        const PARTICLE_COUNT = 50;
+
+        function appendScopedStyles(rules) {
+            if (!rules || !rules.length) {
+                return;
+            }
+
+            const style = document.createElement('style');
+            if (window.__CSP_NONCE__) {
+                style.setAttribute('nonce', window.__CSP_NONCE__);
+            }
+            style.textContent = rules.join('\n');
+            document.head.appendChild(style);
+        }
+
+        function initializeTiltStyles() {
+            if (!scene) {
+                return;
+            }
+
+            const rules = [];
+            for (let x = -MAX_TILT; x <= MAX_TILT; x++) {
+                for (let y = -MAX_TILT; y <= MAX_TILT; y++) {
+                    rules.push(`#scene[data-tilt="${x},${y}"] { transform: rotateY(${x}deg) rotateX(${-y}deg); }`);
+                }
+            }
+            appendScopedStyles(rules);
+            scene.setAttribute('data-tilt', '0,0');
+        }
+
+        function initializeParticles() {
+            if (!particlesContainer) {
+                return;
+            }
+
+            const rules = [];
+            for (let i = 0; i < PARTICLE_COUNT; i++) {
+                const particle = document.createElement('div');
+                particle.className = 'particle';
+                particlesContainer.appendChild(particle);
+
+                const left = (Math.random() * 100).toFixed(2);
+                const top = (Math.random() * 100).toFixed(2);
+                const delay = (Math.random() * 10).toFixed(2);
+                const duration = (Math.random() * 10 + 10).toFixed(2);
+
+                rules.push(`#particles .particle:nth-child(${i + 1}) { left: ${left}%; top: ${top}%; animation-delay: ${delay}s; animation-duration: ${duration}s; }`);
+            }
+
+            appendScopedStyles(rules);
+        }
+
+        initializeTiltStyles();
+        initializeParticles();
+
         document.querySelectorAll('.neo-card').forEach(card => {
             card.addEventListener('mouseenter', () => {
                 isCardHovered = true;
@@ -632,148 +747,628 @@
         });
 
         document.addEventListener('mousemove', (e) => {
-            // Reduce parallax intensity from ±20 to ±8 degrees
-            const x = (e.clientX / window.innerWidth - 0.5) * 8;
-            const y = (e.clientY / window.innerHeight - 0.5) * 8;
-
-            // Only apply parallax when NOT hovering over a card
-            if (!isCardHovered) {
-                scene.style.transform = `rotateY(${x}deg) rotateX(${-y}deg)`;
+            if (!scene) {
+                return;
             }
 
-            mouseXDisplay.textContent = Math.round(x);
-            mouseYDisplay.textContent = Math.round(y);
+            const rawX = (e.clientX / window.innerWidth - 0.5) * (MAX_TILT * 2);
+            const rawY = (e.clientY / window.innerHeight - 0.5) * (MAX_TILT * 2);
+            const tiltX = Math.max(-MAX_TILT, Math.min(MAX_TILT, Math.round(rawX)));
+            const tiltY = Math.max(-MAX_TILT, Math.min(MAX_TILT, Math.round(rawY)));
+
+            if (!isCardHovered) {
+                scene.setAttribute('data-tilt', `${tiltX},${tiltY}`);
+            }
+
+            if (mouseXDisplay) {
+                mouseXDisplay.textContent = tiltX;
+            }
+
+            if (mouseYDisplay) {
+                mouseYDisplay.textContent = tiltY;
+            }
         });
 
-        // Generate ambient particles
-        const particlesContainer = document.getElementById('particles');
-        for (let i = 0; i < 50; i++) {
-            const particle = document.createElement('div');
-            particle.className = 'particle';
-            particle.style.left = Math.random() * 100 + '%';
-            particle.style.top = Math.random() * 100 + '%';
-            particle.style.animationDelay = Math.random() * 10 + 's';
-            particle.style.animationDuration = (Math.random() * 10 + 10) + 's';
-            particlesContainer.appendChild(particle);
+        const projectNameEl = document.getElementById('project-name');
+        const configWarningsEl = document.getElementById('config-warnings');
+        const statusBadgeEl = document.getElementById('status-badge');
+        const statusContentEl = document.getElementById('status-content');
+        const securityBadgeEl = document.getElementById('security-badge');
+        const securityContentEl = document.getElementById('security-content');
+        const toolsBadgeEl = document.getElementById('tools-badge');
+        const toolsContentEl = document.getElementById('tools-content');
+        const issuesListEl = document.getElementById('issues-list');
+        const rescanButtons = document.querySelectorAll('[data-action="refresh-scan"]');
+
+        rescanButtons.forEach(button => {
+            button.addEventListener('click', refreshScan);
+        });
+
+        function renderConfigWarnings(warnings) {
+            if (!configWarningsEl) return;
+
+            const entries = Array.isArray(warnings) ? warnings.filter(Boolean) : [];
+            if (!entries.length) {
+                configWarningsEl.classList.add('hidden');
+                configWarningsEl.replaceChildren();
+                return;
+            }
+
+            configWarningsEl.classList.remove('hidden');
+            const title = document.createElement('strong');
+            title.textContent = entries.length > 1
+                ? 'Configuration warnings detected:'
+                : 'Configuration warning detected:';
+
+            const list = document.createElement('ul');
+            entries.forEach(entry => {
+                const item = document.createElement('li');
+                item.textContent = entry;
+                list.appendChild(item);
+            });
+
+            configWarningsEl.replaceChildren(title, list);
         }
 
-        // Mock data loading (replace with real API calls)
-        setTimeout(() => {
-            loadStatus();
-            loadSecurity();
-            loadTools();
-            loadIssues();
-        }, 1000);
-
-        function loadStatus() {
-            document.getElementById('project-name').textContent = 'intelligent-cloud-guardian';
-            document.getElementById('status-badge').textContent = 'Healthy';
-            document.getElementById('status-badge').className = 'status-badge status-good';
-
-            document.getElementById('status-content').innerHTML = `
-                <div class="metric">
-                    <span class="metric-label">Experience Level</span>
-                    <span class="metric-value">Advanced</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">Dependencies</span>
-                    <span class="metric-value">12</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">Branch</span>
-                    <span class="metric-value">main</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">Uncommitted</span>
-                    <span class="metric-value">4,510</span>
-                </div>
-            `;
+        function updateBadge(element, state) {
+            if (!element) return;
+            const type = state?.type ? ` status-${state.type}` : '';
+            element.className = `status-badge${type}`;
+            element.textContent = state?.text || '—';
         }
 
-        function loadSecurity() {
-            document.getElementById('security-badge').textContent = 'Issues Found';
-            document.getElementById('security-badge').className = 'status-badge status-warning';
+        function createMetricElement({ label, value, detail, nodes = [] }) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'metric';
 
-            document.getElementById('security-content').innerHTML = `
-                <div class="metric">
-                    <span class="metric-label">🔴 Critical</span>
-                    <span class="metric-value">0</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">🟠 High</span>
-                    <span class="metric-value">1</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">🟡 Medium</span>
-                    <span class="metric-value">1</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">⚪ Warnings</span>
-                    <span class="metric-value">3</span>
-                </div>
-                <div style="margin-top: 20px;">
-                    <div class="progress-bar">
-                        <div class="progress-fill" style="width: 85%"></div>
-                        <div class="progress-text">85% Secure</div>
-                    </div>
-                </div>
-            `;
+            const labelContainer = document.createElement('div');
+            labelContainer.className = 'metric-label';
+            labelContainer.textContent = label ?? '—';
+
+            if (detail) {
+                const detailEl = document.createElement('small');
+                detailEl.className = 'metric-detail';
+                detailEl.textContent = detail;
+                labelContainer.appendChild(detailEl);
+            }
+
+            wrapper.appendChild(labelContainer);
+
+            if (value !== undefined) {
+                const valueEl = document.createElement('span');
+                valueEl.className = 'metric-value';
+                valueEl.textContent = value === undefined || value === null ? '—' : String(value);
+                wrapper.appendChild(valueEl);
+            }
+
+            nodes.forEach(node => {
+                if (node) {
+                    wrapper.appendChild(node);
+                }
+            });
+
+            return wrapper;
         }
 
-        function loadTools() {
-            document.getElementById('tools-badge').textContent = '5/5 Found';
-            document.getElementById('tools-badge').className = 'status-badge status-good';
+        function renderMetrics(container, metrics, emptyMessage) {
+            if (!container) return;
 
-            document.getElementById('tools-content').innerHTML = `
-                <div class="metric">
-                    <span class="metric-label">✓ Git</span>
-                    <span class="metric-value">Installed</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ Node.js</span>
-                    <span class="metric-value">v18.0.0</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ npm</span>
-                    <span class="metric-value">v9.0.0</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ Docker</span>
-                    <span class="metric-value">Installed</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ GitHub CLI</span>
-                    <span class="metric-value">Installed</span>
-                </div>
-            `;
+            container.classList.remove('loading');
+            if (!Array.isArray(metrics) || metrics.length === 0) {
+                const message = document.createElement('p');
+                message.textContent = emptyMessage || 'No data available.';
+                container.replaceChildren(message);
+                return;
+            }
+
+            const elements = metrics.map(metric => createMetricElement(metric));
+            container.replaceChildren(...elements);
         }
 
-        function loadIssues() {
-            document.getElementById('issues-list').innerHTML = `
-                <li class="issue-item high">
-                    <span class="issue-icon">🟠</span>
-                    <span class="issue-text">.gitignore missing critical patterns</span>
-                    <button class="holo-button" onclick="fixIssue('gitignore')">Fix</button>
-                </li>
-                <li class="issue-item medium">
-                    <span class="issue-icon">🟡</span>
-                    <span class="issue-text">Missing .env.example for team reference</span>
-                    <button class="holo-button" onclick="fixIssue('env-example')">Fix</button>
-                </li>
-            `;
+        function createSectionLabel(text) {
+            const label = document.createElement('div');
+            label.className = 'section-label';
+            label.textContent = text;
+            return label;
         }
 
-        function fixIssue(issueId) {
-            alert(`Fixing issue: ${issueId}\n\nIn production, this would call the Guardian API to auto-fix the issue.`);
+        function summarizeSecurity(report) {
+            if (report?.security) {
+                const { critical = 0, high = 0, medium = 0, warnings = 0 } = report.security;
+                return { critical, high, medium, warnings };
+            }
+
+            const issues = Array.isArray(report?.issues) ? report.issues : [];
+            const warnings = Array.isArray(report?.warnings) ? report.warnings.length : 0;
+
+            if (!issues.length && warnings === 0) {
+                return null;
+            }
+
+            const summary = { critical: 0, high: 0, medium: 0, warnings };
+            issues.forEach(issue => {
+                const severity = String(issue?.severity || '').toUpperCase();
+                if (severity === 'CRITICAL') summary.critical += 1;
+                else if (severity === 'HIGH') summary.high += 1;
+                else if (severity === 'MEDIUM') summary.medium += 1;
+                else summary.warnings += 1;
+            });
+
+            return summary;
         }
 
-        function refreshScan() {
-            document.getElementById('issues-card').classList.add('active');
-            setTimeout(() => {
-                document.getElementById('issues-card').classList.remove('active');
-                alert('Scan complete! No new issues found.');
-            }, 1000);
+        function severityIcon(level) {
+            const map = {
+                critical: '🔴',
+                high: '🟠',
+                medium: '🟡',
+                low: '⚪'
+            };
+            const normalized = String(level || '').toLowerCase();
+            return map[normalized] || '⚠️';
         }
+
+        function severityClass(level) {
+            const normalized = String(level || '').toLowerCase();
+            return ['critical', 'high', 'medium'].includes(normalized) ? normalized : '';
+        }
+
+        function applyStatus(status) {
+            renderConfigWarnings(status?.configWarnings);
+
+            if (!status) {
+                if (projectNameEl) {
+                    projectNameEl.textContent = 'Nimbus';
+                }
+                updateBadge(statusBadgeEl, { type: 'warning', text: 'Status Unknown' });
+                renderMetrics(statusContentEl, [], 'Project status unavailable.');
+                return;
+            }
+
+            if (projectNameEl) {
+                projectNameEl.textContent = status.projectName || status.package?.name || 'Nimbus';
+            }
+
+            const metrics = [
+                { label: 'Experience Level', value: status.experienceLevel || '—' },
+                { label: 'Dependencies', value: status.package?.dependencies ?? '—' },
+                { label: 'Dev Dependencies', value: status.package?.devDependencies ?? '—' },
+                { label: 'Branch', value: status.git?.branch || '—' }
+            ];
+
+            renderMetrics(statusContentEl, metrics, 'No status metrics available.');
+
+            const hasWarnings = Array.isArray(status.configWarnings) && status.configWarnings.length > 0;
+            updateBadge(statusBadgeEl, {
+                type: hasWarnings ? 'warning' : 'good',
+                text: hasWarnings ? 'Check Config' : 'Healthy'
+            });
+        }
+
+        function applySecurity(report) {
+            const summary = summarizeSecurity(report);
+
+            if (!summary) {
+                updateBadge(securityBadgeEl, { type: 'warning', text: 'Scan Pending' });
+                renderMetrics(securityContentEl, [], 'Run “nimbus scan” to populate security insights.');
+                return;
+            }
+
+            const badgeState = summary.critical > 0
+                ? { type: 'error', text: 'Critical Issues' }
+                : (summary.high > 0 || summary.medium > 0)
+                    ? { type: 'warning', text: 'Issues Detected' }
+                    : { type: 'good', text: 'Secure' };
+
+            updateBadge(securityBadgeEl, badgeState);
+
+            const metrics = [
+                { label: '🔴 Critical', value: summary.critical },
+                { label: '🟠 High', value: summary.high },
+                { label: '🟡 Medium', value: summary.medium },
+                { label: '⚪ Warnings', value: summary.warnings }
+            ];
+
+            renderMetrics(securityContentEl, metrics, 'Security metrics unavailable.');
+        }
+
+        function renderTools(data) {
+            if (!toolsContentEl) return;
+
+            toolsContentEl.classList.remove('loading');
+            const detected = Array.isArray(data?.detected) ? data.detected : [];
+            const missing = Array.isArray(data?.missing) ? data.missing : [];
+
+            if (!detected.length && !missing.length) {
+                updateBadge(toolsBadgeEl, { type: 'warning', text: 'Awaiting Scan' });
+                const message = document.createElement('p');
+                message.textContent = 'Run “nimbus scan” to detect installed tooling.';
+                toolsContentEl.replaceChildren(message);
+                return;
+            }
+
+            const nodes = [];
+
+            if (detected.length) {
+                nodes.push(createSectionLabel('Detected'));
+                detected.slice(0, 8).forEach(tool => {
+                    const name = tool.displayName || tool.name || tool.provider || tool.id || 'Detected Tool';
+                    const detail = tool.category
+                        ? `${tool.category} toolkit`
+                        : tool.version
+                            ? `Version: ${tool.version}`
+                            : '';
+                    nodes.push(createMetricElement({ label: name, value: 'Installed', detail }));
+                });
+            }
+
+            if (missing.length) {
+                nodes.push(createSectionLabel('Missing'));
+                missing.slice(0, 8).forEach(tool => {
+                    const name = tool.displayName || tool.name || tool.provider || tool.id || 'Missing Tool';
+                    const detail = tool.installerDescription || tool.install || tool.reason || 'Installation required.';
+                    const nodesForRow = [];
+                    if (tool.safeInstallerId) {
+                        const button = document.createElement('button');
+                        button.className = 'holo-button';
+                        button.type = 'button';
+                        button.textContent = 'Install';
+                        button.addEventListener('click', () => installTool(tool.safeInstallerId, name));
+                        nodesForRow.push(button);
+                    }
+                    nodes.push(createMetricElement({ label: name, value: 'Missing', detail, nodes: nodesForRow }));
+                });
+            }
+
+            const total = detected.length + missing.length;
+            updateBadge(toolsBadgeEl, missing.length
+                ? { type: 'warning', text: `${detected.length}/${total} Ready` }
+                : { type: 'good', text: 'All Ready' });
+
+            toolsContentEl.replaceChildren(...nodes);
+        }
+
+        function renderIssues(report) {
+            if (!issuesListEl) return;
+
+            issuesListEl.classList.remove('loading');
+
+            const issues = Array.isArray(report?.issues) ? report.issues : [];
+            const recommendations = Array.isArray(report?.recommendations) ? report.recommendations : [];
+
+            if (!issues.length && !recommendations.length) {
+                const item = document.createElement('li');
+                item.className = 'issue-item';
+                const text = document.createElement('span');
+                text.className = 'issue-text';
+                text.textContent = 'No issues detected. Run “nimbus scan” to keep your baseline fresh.';
+                item.appendChild(text);
+                issuesListEl.replaceChildren(item);
+                return;
+            }
+
+            const elements = [];
+
+            issues.slice(0, 10).forEach(issue => {
+                const li = document.createElement('li');
+                li.className = 'issue-item';
+
+                const severityCls = severityClass(issue.severity);
+                if (severityCls) {
+                    li.classList.add(severityCls);
+                }
+
+                const icon = document.createElement('span');
+                icon.className = 'issue-icon';
+                icon.textContent = severityIcon(issue.severity);
+
+                const text = document.createElement('span');
+                text.className = 'issue-text';
+                text.textContent = issue.message || 'Issue detected';
+
+                const detailLines = [];
+                if (issue.file) {
+                    detailLines.push(`File: ${issue.file}`);
+                }
+                if (Array.isArray(issue.details) && issue.details.length) {
+                    detailLines.push(issue.details.join(', '));
+                }
+                if (issue.category) {
+                    detailLines.push(`Category: ${issue.category}`);
+                }
+
+                if (detailLines.length) {
+                    const detail = document.createElement('small');
+                    detail.textContent = detailLines.join(' • ');
+                    text.appendChild(detail);
+                }
+
+                li.append(icon, text);
+
+                if (issue.autoFixable && issue.id) {
+                    const button = document.createElement('button');
+                    button.className = 'holo-button';
+                    button.type = 'button';
+                    button.textContent = 'Auto-fix';
+                    button.addEventListener('click', () => autoFixIssue(issue.id, issue.message || 'Issue'));
+                    li.appendChild(button);
+                }
+
+                elements.push(li);
+            });
+
+            recommendations.slice(0, 4).forEach(rec => {
+                const li = document.createElement('li');
+                li.className = 'issue-item';
+
+                const icon = document.createElement('span');
+                icon.className = 'issue-icon';
+                icon.textContent = '💡';
+
+                const text = document.createElement('span');
+                text.className = 'issue-text';
+                text.textContent = rec.suggestion || rec.reason || 'Recommendation';
+
+                const details = [];
+                if (rec.reason) {
+                    details.push(rec.reason);
+                }
+                if (Array.isArray(rec.options) && rec.options.length) {
+                    const options = rec.options.map(option => option.name).filter(Boolean);
+                    if (options.length) {
+                        details.push(`Options: ${options.join(', ')}`);
+                    }
+                }
+
+                if (details.length) {
+                    const detail = document.createElement('small');
+                    detail.textContent = details.join(' • ');
+                    text.appendChild(detail);
+                }
+
+                li.append(icon, text);
+                elements.push(li);
+            });
+
+            issuesListEl.replaceChildren(...elements);
+        }
+
+        function updateCsrfTokenFromResponse(response) {
+            if (!response || typeof response.headers?.get !== 'function') {
+                return;
+            }
+
+            const nextToken = response.headers.get('X-CSRF-Token');
+            if (!nextToken || typeof nextToken !== 'string') {
+                return;
+            }
+
+            const trimmed = nextToken.trim();
+            if (!trimmed || trimmed === window.__CSRF_TOKEN__) {
+                return;
+            }
+
+            window.__CSRF_TOKEN__ = trimmed;
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            if (meta) {
+                meta.setAttribute('content', trimmed);
+            }
+        }
+
+        function getRetryAfterSeconds(response) {
+            if (!response || typeof response.headers?.get !== 'function') {
+                return null;
+            }
+
+            const retryAfter = response.headers.get('Retry-After');
+            if (!retryAfter) {
+                return null;
+            }
+
+            const seconds = Number.parseInt(retryAfter, 10);
+            return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+        }
+
+        function formatRateLimitMessage(response, baseMessage) {
+            const seconds = getRetryAfterSeconds(response);
+            if (!seconds) {
+                return baseMessage;
+            }
+
+            const unit = seconds === 1 ? 'second' : 'seconds';
+            return `${baseMessage} Try again in ${seconds} ${unit}.`;
+        }
+
+        function buildErrorMessage(response, result, fallback) {
+            const base = result?.error || result?.message || fallback;
+            if (response?.status === 429) {
+                return formatRateLimitMessage(response, base);
+            }
+            return base;
+        }
+
+        async function fetchJSON(url) {
+            try {
+                const response = await fetch(url, {
+                    headers: { Accept: 'application/json' },
+                    cache: 'no-store',
+                    credentials: 'same-origin'
+                });
+
+                updateCsrfTokenFromResponse(response);
+
+                if (!response.ok) {
+                    if (response.status === 401) {
+                        console.warn('[dashboard] Session expired; reload required.');
+                        return null;
+                    }
+                    if (response.status === 429) {
+                        const message = formatRateLimitMessage(response, 'Request throttled.');
+                        console.warn(`[dashboard] ${message}`);
+                        return null;
+                    }
+                    if (response.status !== 404) {
+                        console.warn(`[dashboard] Failed to load ${url}: ${response.status}`);
+                    }
+                    return null;
+                }
+
+                return await response.json();
+            } catch (error) {
+                console.warn(`[dashboard] Error loading ${url}:`, error);
+                return null;
+            }
+        }
+
+        async function hydrate() {
+            const [status, tools, report] = await Promise.all([
+                fetchJSON('/api/status'),
+                fetchJSON('/api/tools'),
+                fetchJSON(`/guardian-test-report.json?ts=${Date.now()}`)
+            ]);
+
+            applyStatus(status || null);
+
+            if (report) {
+                applySecurity(report);
+                renderIssues(report);
+            } else {
+                applySecurity(null);
+                renderIssues(null);
+            }
+
+            if (tools) {
+                renderTools(tools);
+            } else if (report?.tools) {
+                renderTools(report.tools);
+            } else {
+                renderTools(null);
+            }
+        }
+
+        async function installTool(toolId, toolName) {
+            if (!toolId) {
+                alert('Manual installation required for this tool.');
+                return;
+            }
+
+            const label = toolName || 'tool';
+            if (!confirm(`Install ${label}?`)) {
+                return;
+            }
+
+            try {
+                const response = await fetch('/api/install-tool', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': window.__CSRF_TOKEN__
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ toolId })
+                });
+
+                updateCsrfTokenFromResponse(response);
+
+                const result = await response.json().catch(() => ({}));
+
+                if (!response.ok || !result.success) {
+                    if (response.status === 401) {
+                        alert('Your session expired. Please reload the dashboard.');
+                        return;
+                    }
+                    const message = buildErrorMessage(response, result, 'Installation failed.');
+                    throw new Error(message);
+                }
+
+                alert(result.message || `${label} installed successfully.`);
+                await hydrate();
+            } catch (error) {
+                alert(`Failed to install ${label}: ${error.message}`);
+            }
+        }
+
+        async function autoFixIssue(issueId, label) {
+            if (!issueId) return;
+
+            const issueLabel = label || 'issue';
+            if (!confirm(`Attempt auto-fix for ${issueLabel}?`)) {
+                return;
+            }
+
+            try {
+                const response = await fetch('/api/fix', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': window.__CSRF_TOKEN__
+                    },
+                    credentials: 'same-origin',
+                    body: JSON.stringify({ issueId })
+                });
+
+                updateCsrfTokenFromResponse(response);
+
+                const result = await response.json().catch(() => ({}));
+
+                if (!response.ok || result?.error) {
+                    if (response.status === 401) {
+                        alert('Your session expired. Please reload the dashboard.');
+                        return;
+                    }
+                    const message = buildErrorMessage(response, result, 'Auto-fix failed.');
+                    throw new Error(message);
+                }
+
+                alert(result.message || 'Issue auto-fixed.');
+                await hydrate();
+            } catch (error) {
+                alert(`Auto-fix failed: ${error.message}`);
+            }
+        }
+
+        async function refreshScan() {
+            const issuesCard = document.getElementById('issues-card');
+            issuesCard?.classList.add('active');
+
+            try {
+                const response = await fetch('/api/scan', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': window.__CSRF_TOKEN__
+                    },
+                    credentials: 'same-origin'
+                });
+
+                updateCsrfTokenFromResponse(response);
+
+                const result = await response.json().catch(() => ({}));
+
+                if (!response.ok) {
+                    if (response.status === 401) {
+                        alert('Your session expired. Please reload the dashboard.');
+                        return;
+                    }
+                    const message = buildErrorMessage(response, result, 'Scan failed.');
+                    throw new Error(message);
+                }
+
+                applySecurity(result);
+                renderIssues(result);
+                if (result.tools) {
+                    renderTools(result.tools);
+                }
+
+                alert('Scan complete! Dashboard updated with latest results.');
+            } catch (error) {
+                alert(`Scan failed: ${error.message}`);
+            } finally {
+                issuesCard?.classList.remove('active');
+            }
+        }
+
+        hydrate();
 
         // Card click effects
         document.querySelectorAll('.neo-card').forEach(card => {

--- a/dashboard-server.js
+++ b/dashboard-server.js
@@ -12,16 +12,100 @@ const http = require('http');
 const fs = require('fs-extra');
 const path = require('path');
 const { execSync } = require('child_process');
+const crypto = require('crypto');
 const GuardianEngine = require('./guardian-engine');
 const ToolDetector = require('./tool-detector');
 const AIAssistant = require('./ai-assistant');
+const { loadConfig: loadGuardianConfig } = require('./lib/config-service');
+const SessionManager = require('./lib/session-manager');
+const RateLimiter = require('./lib/rate-limiter');
+
+class HttpError extends Error {
+    constructor(statusCode, message) {
+        super(message);
+        this.name = 'HttpError';
+        this.statusCode = statusCode;
+    }
+}
+
+const normalizeToolId = (value) => {
+    return value
+        ? value
+            .toString()
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+        : null;
+};
+
+const normalizeOrigin = (origin) => {
+    if (!origin) return origin;
+    return origin.endsWith('/') ? origin.slice(0, -1) : origin;
+};
+
+const SAFE_TOOL_INSTALLERS = Object.freeze({
+    'firebase-tools': {
+        command: 'npm install -g firebase-tools',
+        displayName: 'Firebase CLI',
+        description: 'Installs the Firebase CLI globally using npm.',
+        successMessage: 'Firebase CLI installed successfully.'
+    },
+    'vercel': {
+        command: 'npm install -g vercel',
+        displayName: 'Vercel CLI',
+        description: 'Installs the Vercel CLI globally using npm.',
+        successMessage: 'Vercel CLI installed successfully.'
+    },
+    'netlify-cli': {
+        command: 'npm install -g netlify-cli',
+        displayName: 'Netlify CLI',
+        description: 'Installs the Netlify CLI globally using npm.',
+        successMessage: 'Netlify CLI installed successfully.'
+    },
+    'supabase': {
+        command: 'npm install -g supabase',
+        displayName: 'Supabase CLI',
+        description: 'Installs the Supabase CLI globally using npm.',
+        successMessage: 'Supabase CLI installed successfully.'
+    }
+});
 
 class DashboardServer {
     constructor(port = 3333) {
         this.port = port;
         this.projectPath = process.cwd();
         this.config = null;
+        this.configWarnings = [];
         this.cache = {};
+        this.sessionManager = new SessionManager();
+        this.sessionCookieName = 'guardian_session';
+        this.rateLimitProfiles = {
+            action: {
+                name: 'action',
+                limiter: new RateLimiter({ windowMs: 60 * 1000, max: 40 }),
+                message: 'Too many dashboard actions. Please slow down before trying again.'
+            },
+            scan: {
+                name: 'scan',
+                limiter: new RateLimiter({ windowMs: 5 * 60 * 1000, max: 2 }),
+                message: 'Security scans are throttled. Wait a moment before running another scan.'
+            },
+            chat: {
+                name: 'chat',
+                limiter: new RateLimiter({ windowMs: 60 * 1000, max: 8 }),
+                message: 'Too many chat requests in a short time. Pause briefly before asking again.'
+            },
+            install: {
+                name: 'install',
+                limiter: new RateLimiter({ windowMs: 10 * 60 * 1000, max: 3 }),
+                message: 'Tool installation attempts are limited. Please wait before trying again.'
+            }
+        };
+        this.allowedOrigins = new Set([
+            `http://localhost:${this.port}`,
+            `http://127.0.0.1:${this.port}`,
+            `http://[::1]:${this.port}`
+        ].map(normalizeOrigin));
     }
 
     async start() {
@@ -46,16 +130,10 @@ class DashboardServer {
     }
 
     async loadConfig() {
-        const configPath = path.join(this.projectPath, '.guardian', 'config.json');
-        try {
-            this.config = await fs.readJson(configPath);
-            require('dotenv').config({ path: path.join(this.projectPath, '.guardian', '.env') });
-        } catch {
-            this.config = {
-                projectName: path.basename(this.projectPath),
-                experienceLevel: 'intermediate'
-            };
-        }
+        this.config = await loadGuardianConfig(this.projectPath, { createIfMissing: true });
+        this.configWarnings = Array.isArray(this.config?.__meta?.warnings)
+            ? this.config.__meta.warnings.filter(Boolean)
+            : [];
     }
 
     async handleRequest(req, res) {
@@ -68,7 +146,7 @@ class DashboardServer {
 
         // Serve dashboard HTML
         if (url.pathname === '/' || url.pathname === '/index.html') {
-            return this.serveDashboard(res);
+            return this.serveDashboard(req, res);
         }
 
         // 404
@@ -76,18 +154,210 @@ class DashboardServer {
         res.end('Not found');
     }
 
+    applyApiSecurityHeaders(res) {
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.setHeader('X-Content-Type-Options', 'nosniff');
+        res.setHeader('Referrer-Policy', 'same-origin');
+        res.setHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+        res.setHeader('Cache-Control', 'no-store');
+    }
+
+    generateNonce(size = 16) {
+        return crypto.randomBytes(size).toString('base64');
+    }
+
+    applyHtmlSecurityHeaders(res, nonce) {
+        const effectiveNonce = nonce || this.generateNonce();
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.setHeader('X-Content-Type-Options', 'nosniff');
+        res.setHeader('Referrer-Policy', 'same-origin');
+        res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+        res.setHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+        res.setHeader('Cache-Control', 'no-store');
+        res.setHeader(
+            'Content-Security-Policy',
+            [
+                "default-src 'self'",
+                `script-src 'self' 'nonce-${effectiveNonce}'`,
+                `style-src 'self' 'nonce-${effectiveNonce}' https://fonts.googleapis.com`,
+                "font-src 'self' https://fonts.gstatic.com",
+                "img-src 'self' data:",
+                "connect-src 'self'"
+            ].join('; ')
+        );
+    }
+
+    parseCookies(req) {
+        const header = req.headers?.cookie;
+        if (!header) {
+            return {};
+        }
+
+        return header.split(';').reduce((acc, part) => {
+            if (!part) {
+                return acc;
+            }
+
+            const [name, ...valueParts] = part.trim().split('=');
+            if (!name) {
+                return acc;
+            }
+
+            const value = valueParts.join('=');
+            acc[name] = value ? decodeURIComponent(value) : '';
+            return acc;
+        }, {});
+    }
+
+    getSessionIdFromRequest(req) {
+        const cookies = this.parseCookies(req);
+        return cookies[this.sessionCookieName];
+    }
+
+    setSessionCookie(res, sessionId) {
+        if (!sessionId) {
+            return;
+        }
+
+        const maxAgeSeconds = Math.max(1, Math.floor(this.sessionManager.ttlMs / 1000));
+        const cookieValue = `${this.sessionCookieName}=${sessionId}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${maxAgeSeconds}`;
+        const existing = res.getHeader('Set-Cookie');
+
+        if (existing) {
+            const values = Array.isArray(existing) ? existing.slice() : [existing];
+            values.push(cookieValue);
+            res.setHeader('Set-Cookie', values);
+        } else {
+            res.setHeader('Set-Cookie', cookieValue);
+        }
+    }
+
+    establishBrowserSession(req, res, options = {}) {
+        const { rotateCsrf = false } = options;
+        const existingId = this.getSessionIdFromRequest(req);
+        let session = existingId
+            ? this.sessionManager.touchSession(existingId, { rotateCsrf })
+            : null;
+
+        if (!session) {
+            session = this.sessionManager.createSession();
+            if (rotateCsrf) {
+                session = this.sessionManager.touchSession(session.id, { rotateCsrf: true }) || session;
+            }
+        }
+
+        this.setSessionCookie(res, session.id);
+        return session;
+    }
+
+    getSessionForRequest(req, res) {
+        const sessionId = this.getSessionIdFromRequest(req);
+        if (!sessionId) {
+            return null;
+        }
+
+        const session = this.sessionManager.touchSession(sessionId);
+        if (session) {
+            this.setSessionCookie(res, session.id);
+        }
+
+        return session;
+    }
+
+    getRateLimitDescriptor(pathname, method) {
+        if (method !== 'POST') {
+            return null;
+        }
+
+        if (pathname === '/api/scan') {
+            return this.rateLimitProfiles.scan;
+        }
+
+        if (pathname === '/api/chat') {
+            return this.rateLimitProfiles.chat;
+        }
+
+        if (pathname === '/api/install-tool') {
+            return this.rateLimitProfiles.install;
+        }
+
+        return this.rateLimitProfiles.action;
+    }
+
+    applyRateLimit(descriptor, session, res) {
+        if (!descriptor || !session) {
+            return true;
+        }
+
+        const key = `${session.id}:${descriptor.name}`;
+        const outcome = descriptor.limiter.consume(key);
+
+        res.setHeader('X-RateLimit-Limit', descriptor.limiter.max);
+        res.setHeader('X-RateLimit-Remaining', Math.max(0, outcome.remaining));
+        res.setHeader('X-RateLimit-Reset', Math.max(0, Math.ceil(outcome.resetMs / 1000)));
+
+        if (!outcome.allowed) {
+            const retryAfterSeconds = Math.max(1, Math.ceil(outcome.retryAfterMs / 1000));
+            res.setHeader('Retry-After', retryAfterSeconds);
+            res.writeHead(429);
+            res.end(JSON.stringify({ error: descriptor.message }));
+            return false;
+        }
+
+        return true;
+    }
+
     async handleAPI(url, req, res) {
-        res.setHeader('Content-Type', 'application/json');
-        res.setHeader('Access-Control-Allow-Origin', '*');
+        this.applyApiSecurityHeaders(res);
+        res.setHeader('Vary', 'Origin');
+
+        const requestOrigin = normalizeOrigin(req.headers.origin);
+        if (requestOrigin) {
+            if (!this.allowedOrigins.has(requestOrigin)) {
+                res.writeHead(403);
+                res.end(JSON.stringify({ error: 'Origin not allowed' }));
+                return;
+            }
+            res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+        } else {
+            res.setHeader('Access-Control-Allow-Origin', `http://localhost:${this.port}`);
+        }
+
         res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-CSRF-Token, Accept');
+        res.setHeader('Access-Control-Allow-Credentials', 'true');
 
         // Handle OPTIONS preflight
         if (req.method === 'OPTIONS') {
-            res.writeHead(200);
+            res.writeHead(204);
             res.end();
             return;
         }
+
+        const session = this.getSessionForRequest(req, res);
+        if (!session) {
+            res.writeHead(401);
+            res.end(JSON.stringify({ error: 'Session expired. Reload the dashboard.' }));
+            return;
+        }
+
+        res.setHeader('X-CSRF-Token', session.csrfToken);
+
+        if (req.method !== 'GET') {
+            const csrfHeader = req.headers['x-csrf-token'];
+            if (!csrfHeader || csrfHeader !== session.csrfToken) {
+                res.writeHead(403);
+                res.end(JSON.stringify({ error: 'Invalid CSRF token' }));
+                return;
+            }
+        }
+
+        const rateLimitDescriptor = this.getRateLimitDescriptor(url.pathname, req.method);
+        if (!this.applyRateLimit(rateLimitDescriptor, session, res)) {
+            return;
+        }
+
+        await this.loadConfig();
 
         try {
             // GET /api/status - Overall project status
@@ -111,6 +381,16 @@ class DashboardServer {
             if (url.pathname === '/api/tools' && req.method === 'GET') {
                 const detector = new ToolDetector(this.projectPath);
                 const tools = await detector.analyze();
+                tools.missing = tools.missing.map(tool => {
+                    const safeInstallerId = this.getSafeInstallerId(tool);
+                    const installer = safeInstallerId ? SAFE_TOOL_INSTALLERS[safeInstallerId] : null;
+                    return {
+                        ...tool,
+                        safeInstallerId,
+                        installerLabel: installer?.displayName,
+                        installerDescription: installer?.description
+                    };
+                });
                 res.writeHead(200);
                 res.end(JSON.stringify(tools));
                 return;
@@ -118,8 +398,10 @@ class DashboardServer {
 
             // POST /api/fix - Auto-fix an issue
             if (url.pathname === '/api/fix' && req.method === 'POST') {
-                const body = await this.readRequestBody(req);
-                const { issueId } = JSON.parse(body);
+                const { issueId } = await this.parseJsonBody(req);
+                if (!issueId || typeof issueId !== 'string') {
+                    throw new HttpError(400, 'issueId is required');
+                }
                 const engine = new GuardianEngine(this.projectPath, this.config);
                 const result = await engine.autoFix(issueId);
                 res.writeHead(200);
@@ -129,11 +411,13 @@ class DashboardServer {
 
             // POST /api/chat - Chat with AI
             if (url.pathname === '/api/chat' && req.method === 'POST') {
-                const body = await this.readRequestBody(req);
-                const { message } = JSON.parse(body);
+                const { message } = await this.parseJsonBody(req);
+                if (!message || typeof message !== 'string') {
+                    throw new HttpError(400, 'message is required');
+                }
                 const ai = new AIAssistant({
-                    claudeApiKey: process.env.CLAUDE_API_KEY,
-                    geminiApiKey: process.env.GEMINI_API_KEY,
+                    claudeApiKey: this.config.claudeApiKey || process.env.CLAUDE_API_KEY,
+                    geminiApiKey: this.config.geminiApiKey || process.env.GEMINI_API_KEY,
                     experienceLevel: this.config.experienceLevel
                 });
                 const response = await ai.ask(message);
@@ -168,10 +452,12 @@ class DashboardServer {
 
             // POST /api/install-tool - Install missing tool
             if (url.pathname === '/api/install-tool' && req.method === 'POST') {
-                const body = await this.readRequestBody(req);
-                const { tool, command } = JSON.parse(body);
-                const result = await this.installTool(command);
-                res.writeHead(200);
+                const { toolId } = await this.parseJsonBody(req);
+                if (!toolId || typeof toolId !== 'string') {
+                    throw new HttpError(400, 'toolId is required');
+                }
+                const result = await this.installTool(toolId);
+                res.writeHead(result.success ? 200 : 400);
                 res.end(JSON.stringify(result));
                 return;
             }
@@ -180,20 +466,51 @@ class DashboardServer {
             res.end(JSON.stringify({ error: 'API endpoint not found' }));
 
         } catch (error) {
+            if (error instanceof HttpError || error.statusCode) {
+                const statusCode = error.statusCode || 500;
+                res.writeHead(statusCode);
+                res.end(JSON.stringify({ error: error.message }));
+                return;
+            }
+
             console.error('API Error:', error);
             res.writeHead(500);
-            res.end(JSON.stringify({ error: error.message }));
+            res.end(JSON.stringify({ error: 'Internal server error' }));
         }
     }
 
     // Helper to read request body
-    readRequestBody(req) {
+    readRequestBody(req, maxBytes = 1024 * 1024) {
         return new Promise((resolve, reject) => {
             let body = '';
-            req.on('data', chunk => body += chunk);
+            let received = 0;
+
+            req.on('data', chunk => {
+                received += chunk.length;
+                if (received > maxBytes) {
+                    req.destroy();
+                    reject(new HttpError(413, 'Payload too large'));
+                    return;
+                }
+                body += chunk;
+            });
+
             req.on('end', () => resolve(body));
             req.on('error', reject);
         });
+    }
+
+    async parseJsonBody(req, options = {}) {
+        const body = await this.readRequestBody(req, options.maxBytes);
+        if (!body) {
+            return {};
+        }
+
+        try {
+            return JSON.parse(body);
+        } catch {
+            throw new HttpError(400, 'Invalid JSON payload');
+        }
     }
 
     async getProjectStatus() {
@@ -201,7 +518,8 @@ class DashboardServer {
             projectName: this.config.projectName,
             path: this.projectPath,
             experienceLevel: this.config.experienceLevel,
-            timestamp: new Date().toISOString()
+            timestamp: new Date().toISOString(),
+            configWarnings: [...this.configWarnings]
         };
 
         // Package.json info
@@ -336,41 +654,93 @@ class DashboardServer {
         }
     }
 
-    async installTool(command) {
+    async installTool(toolId) {
+        const normalizedId = normalizeToolId(toolId);
+        if (!normalizedId) {
+            return { success: false, message: 'Invalid tool identifier.' };
+        }
+
+        const installer = SAFE_TOOL_INSTALLERS[normalizedId];
+        if (!installer) {
+            return { success: false, message: 'This tool must be installed manually.' };
+        }
+
         try {
-            execSync(command, {
+            execSync(installer.command, {
                 cwd: this.projectPath,
-                stdio: 'inherit'
+                stdio: 'inherit',
+                shell: true,
+                timeout: 5 * 60 * 1000
             });
-            return { success: true, message: 'Tool installed successfully' };
+
+            return {
+                success: true,
+                message: installer.successMessage || `${installer.displayName || normalizedId} installed successfully.`
+            };
         } catch (error) {
-            return { success: false, message: error.message };
+            const errorMessage = error.stderr?.toString().trim() || error.stdout?.toString().trim() || error.message;
+            return {
+                success: false,
+                message: errorMessage || 'Installation failed.'
+            };
         }
     }
 
-    async serveDashboard(res) {
-        res.setHeader('Content-Type', 'text/html');
+    getSafeInstallerId(tool) {
+        const candidates = [
+            tool.safeInstallerId,
+            tool.id,
+            tool.cli,
+            tool.name,
+            tool.command
+        ];
+
+        for (const candidate of candidates) {
+            const normalized = normalizeToolId(candidate);
+            if (normalized && SAFE_TOOL_INSTALLERS[normalized]) {
+                return normalized;
+            }
+        }
+
+        return null;
+    }
+
+    async serveDashboard(req, res) {
+        const session = this.establishBrowserSession(req, res, { rotateCsrf: true });
+        const nonce = this.generateNonce();
+        this.applyHtmlSecurityHeaders(res, nonce);
         res.writeHead(200);
 
         // Check if holographic dashboard exists
         const holographicPath = path.join(__dirname, 'dashboard-holographic.html');
         try {
             const holographicHTML = await fs.readFile(holographicPath, 'utf-8');
-            res.end(holographicHTML);
+            res.end(this.injectSecurityContext(holographicHTML, nonce, session.csrfToken));
         } catch {
             // Fallback to built-in dashboard
-            res.end(this.getDashboardHTML());
+            res.end(this.getDashboardHTML(nonce, session.csrfToken));
         }
     }
 
-    getDashboardHTML() {
+    injectSecurityContext(html, nonce, csrfToken) {
+        return html
+            .replace(/__CSRF_TOKEN__/g, csrfToken)
+            .replace(/__CSP_NONCE__/g, nonce);
+    }
+
+    getDashboardHTML(nonce, csrfToken) {
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="${csrfToken}">
     <title>Cloud Guardian Dashboard</title>
-    <style>
+    <script nonce="${nonce}">
+        window.__CSRF_TOKEN__ = '${csrfToken}';
+        window.__CSP_NONCE__ = '${nonce}';
+    </script>
+    <style nonce="${nonce}">
         * {
             margin: 0;
             padding: 0;
@@ -527,6 +897,14 @@ class DashboardServer {
             font-size: 14px;
         }
 
+        .issue-file {
+            display: block;
+            font-size: 12px;
+            color: #666;
+            margin-top: 4px;
+            word-break: break-all;
+        }
+
         .btn {
             background: #667eea;
             color: white;
@@ -566,9 +944,59 @@ class DashboardServer {
             font-weight: 600;
         }
 
+        .tool-install-warning {
+            color: #c05621;
+            font-weight: 600;
+            font-size: 12px;
+        }
+
         .tool-missing {
             color: #dc3545;
             font-weight: 600;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 20px;
+            color: #333;
+        }
+
+        .section-title {
+            margin: 20px 0 15px;
+            font-size: 16px;
+            font-weight: 600;
+            color: #333;
+        }
+
+        .section-title--compact {
+            margin-top: 0;
+        }
+
+        .tool-meta {
+            font-size: 12px;
+            color: #666;
+        }
+
+        .tool-doc-link {
+            font-size: 12px;
+        }
+
+        .tool-doc-link a {
+            color: #0d6efd;
+            text-decoration: none;
+        }
+
+        .tool-doc-link a:hover,
+        .tool-doc-link a:focus {
+            text-decoration: underline;
+        }
+
+        .text-danger {
+            color: #dc3545;
+        }
+
+        .is-hidden {
+            display: none !important;
         }
 
         .chat-container {
@@ -594,6 +1022,19 @@ class DashboardServer {
             display: flex;
             justify-content: space-between;
             align-items: center;
+        }
+
+        .chat-close-button {
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 20px;
+            color: #333;
+        }
+
+        .chat-close-button:focus-visible {
+            outline: 2px solid #667eea;
+            outline-offset: 2px;
         }
 
         .chat-messages {
@@ -717,13 +1158,13 @@ class DashboardServer {
     </div>
 
     <!-- AI Chat FAB -->
-    <button class="chat-fab" onclick="toggleChat()">💬</button>
+    <button class="chat-fab" type="button" data-action="toggle-chat">💬</button>
 
     <!-- AI Chat Container -->
     <div class="chat-container" id="chat-container">
         <div class="chat-header">
             <h3>🤖 AI Assistant</h3>
-            <button onclick="toggleChat()" style="background: none; border: none; cursor: pointer; font-size: 20px;">✕</button>
+            <button type="button" class="chat-close-button" data-action="toggle-chat">✕</button>
         </div>
         <div class="chat-messages" id="chat-messages"></div>
         <div class="chat-input-container">
@@ -732,13 +1173,159 @@ class DashboardServer {
                 class="chat-input"
                 id="chat-input"
                 placeholder="Ask me anything..."
-                onkeypress="handleChatKeypress(event)"
             />
         </div>
     </div>
 
-    <script>
-        let chatHistory = [];
+    <script nonce="${nonce}">
+        const escapeHtml = (value) => {
+            if (value === undefined || value === null) {
+                return '';
+            }
+
+            return value
+                .toString()
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        };
+
+        const formatMultiline = (value) => escapeHtml(value).replace(/\n/g, '<br>');
+
+        const getJsonHeaders = () => {
+            const headers = { 'Content-Type': 'application/json' };
+            if (window.__CSRF_TOKEN__) {
+                headers['X-CSRF-Token'] = window.__CSRF_TOKEN__;
+            }
+            return headers;
+        };
+
+        function updateCsrfTokenFromResponse(response) {
+            if (!response || typeof response.headers?.get !== 'function') {
+                return;
+            }
+
+            const nextToken = response.headers.get('X-CSRF-Token');
+            if (!nextToken || typeof nextToken !== 'string') {
+                return;
+            }
+
+            const trimmed = nextToken.trim();
+            if (!trimmed || trimmed === window.__CSRF_TOKEN__) {
+                return;
+            }
+
+            window.__CSRF_TOKEN__ = trimmed;
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            if (meta) {
+                meta.setAttribute('content', trimmed);
+            }
+        }
+
+        function wireStaticEventHandlers() {
+            document.querySelectorAll('[data-action="toggle-chat"]').forEach(element => {
+                if (element.__guardianBound) {
+                    return;
+                }
+                element.__guardianBound = true;
+                element.addEventListener('click', toggleChat);
+            });
+
+            const chatInput = document.getElementById('chat-input');
+            if (chatInput && !chatInput.__guardianBound) {
+                chatInput.__guardianBound = true;
+                chatInput.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' && !event.shiftKey) {
+                        event.preventDefault();
+                        handleChatKeypress(event);
+                    }
+                });
+            }
+        }
+
+        function wireDynamicActions(root) {
+            const scope = root || document;
+
+            scope.querySelectorAll('[data-action="fix-issue"]').forEach(button => {
+                if (button.__guardianBound) {
+                    return;
+                }
+                button.__guardianBound = true;
+                button.addEventListener('click', () => {
+                    const issueId = button.dataset.issueId;
+                    if (issueId) {
+                        fixIssue(issueId);
+                    }
+                });
+            });
+
+            scope.querySelectorAll('[data-action="install-tool"]').forEach(button => {
+                if (button.__guardianBound) {
+                    return;
+                }
+                button.__guardianBound = true;
+                button.addEventListener('click', () => {
+                    const toolId = button.dataset.toolId || '';
+                    const toolName = button.dataset.toolName || '';
+                    installTool(toolId || null, toolName || null);
+                });
+            });
+        }
+
+        function getRetryAfterSeconds(response) {
+            if (!response || typeof response.headers?.get !== 'function') {
+                return null;
+            }
+
+            const retryAfter = response.headers.get('Retry-After');
+            if (!retryAfter) {
+                return null;
+            }
+
+            const seconds = Number.parseInt(retryAfter, 10);
+            return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+        }
+
+        function formatRateLimitMessage(response, baseMessage) {
+            const seconds = getRetryAfterSeconds(response);
+            if (!seconds) {
+                return baseMessage;
+            }
+
+            const unit = seconds === 1 ? 'second' : 'seconds';
+            return baseMessage + ' Try again in ' + seconds + ' ' + unit + '.';
+        }
+
+        async function parseJsonResponse(response) {
+            updateCsrfTokenFromResponse(response);
+
+            const text = await response.text();
+            let data = {};
+
+            if (text) {
+                try {
+                    data = JSON.parse(text);
+                } catch (error) {
+                    throw new Error('Invalid server response.');
+                }
+            }
+
+            if (!response.ok) {
+                let message = data && (data.error || data.message)
+                    ? (data.error || data.message)
+                    : 'Request failed (' + response.status + ')';
+
+                if (response.status === 429) {
+                    message = formatRateLimitMessage(response, message);
+                }
+
+                throw new Error(message);
+            }
+
+            return data;
+        }
 
         async function loadDashboard() {
             await Promise.all([
@@ -751,40 +1338,54 @@ class DashboardServer {
 
         async function loadProjectStatus() {
             try {
-                const res = await fetch('/api/status');
-                const data = await res.json();
+                const res = await fetch('/api/status', {
+                    credentials: 'same-origin'
+                });
+                const data = await parseJsonResponse(res);
 
-                document.getElementById('project-name').textContent =
-                    data.projectName + ' • ' + data.path;
+                const name = data.projectName || 'Project';
+                const projectPath = data.path ? ' • ' + data.path : '';
+                document.getElementById('project-name').textContent = name + projectPath;
 
                 const metrics = document.getElementById('project-metrics');
                 metrics.className = '';
-                metrics.innerHTML = \`
-                    <div class="metric">
-                        <span class="metric-label">Experience Level</span>
-                        <span class="metric-value">\${data.experienceLevel}</span>
-                    </div>
-                    \${data.package ? \`
-                        <div class="metric">
-                            <span class="metric-label">Dependencies</span>
-                            <span class="metric-value">\${data.package.dependencies}</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-label">Dev Dependencies</span>
-                            <span class="metric-value">\${data.package.devDependencies}</span>
-                        </div>
-                    \` : ''}
-                    \${data.git ? \`
-                        <div class="metric">
-                            <span class="metric-label">Branch</span>
-                            <span class="metric-value">\${data.git.branch}</span>
-                        </div>
-                        <div class="metric">
-                            <span class="metric-label">Uncommitted Changes</span>
-                            <span class="metric-value">\${data.git.uncommitted}</span>
-                        </div>
-                    \` : ''}
-                \`;
+
+                const experienceMetric = '<div class="metric">' +
+                    '<span class="metric-label">Experience Level</span>' +
+                    '<span class="metric-value">' + escapeHtml(data.experienceLevel || 'intermediate') + '</span>' +
+                '</div>';
+
+                const sections = [experienceMetric];
+
+                if (data.package) {
+                    sections.push(
+                        '<div class="metric">' +
+                            '<span class="metric-label">Dependencies</span>' +
+                            '<span class="metric-value">' + escapeHtml(data.package.dependencies ?? 0) + '</span>' +
+                        '</div>' +
+                        '<div class="metric">' +
+                            '<span class="metric-label">Dev Dependencies</span>' +
+                            '<span class="metric-value">' + escapeHtml(data.package.devDependencies ?? 0) + '</span>' +
+                        '</div>'
+                    );
+                }
+
+                if (data.git) {
+                    const branchValue = escapeHtml(data.git.branch || 'unknown');
+                    const uncommittedValue = escapeHtml(data.git.uncommitted ?? 0);
+                    sections.push(
+                        '<div class="metric">' +
+                            '<span class="metric-label">Branch</span>' +
+                            '<span class="metric-value">' + branchValue + '</span>' +
+                        '</div>' +
+                        '<div class="metric">' +
+                            '<span class="metric-label">Uncommitted Changes</span>' +
+                            '<span class="metric-value">' + uncommittedValue + '</span>' +
+                        '</div>'
+                    );
+                }
+
+                metrics.innerHTML = sections.join('');
             } catch (error) {
                 console.error('Failed to load status:', error);
             }
@@ -792,8 +1393,12 @@ class DashboardServer {
 
         async function loadSecurityScan() {
             try {
-                const res = await fetch('/api/scan');
-                const data = await res.json();
+                const res = await fetch('/api/scan', {
+                    method: 'POST',
+                    headers: getJsonHeaders(),
+                    credentials: 'same-origin'
+                });
+                const data = await parseJsonResponse(res);
 
                 const critical = data.issues.filter(i => i.severity === 'CRITICAL').length;
                 const high = data.issues.filter(i => i.severity === 'HIGH').length;
@@ -837,48 +1442,85 @@ class DashboardServer {
                 issuesList.className = 'issue-list';
 
                 if (data.issues.length === 0) {
-                    issuesList.innerHTML = '<div class="metric-label" style="text-align: center; padding: 20px;">✅ No issues found!</div>';
+                    issuesList.innerHTML = '<li class="empty-state">✅ No issues found!</li>';
                 } else {
-                    issuesList.innerHTML = data.issues.slice(0, 10).map(issue => \`
-                        <li class="issue-item">
-                            <span class="issue-icon">\${getSeverityIcon(issue.severity)}</span>
-                            <span class="issue-text">\${issue.message}</span>
-                            \${issue.autoFixable ? '<button class="btn btn-small" onclick="fixIssue(\'' + issue.id + '\')">Fix</button>' : ''}
-                        </li>
-                    \`).join('');
+                    const issuesHtml = data.issues.slice(0, 10).map(issue => {
+                        const message = formatMultiline(issue.message || 'Issue detected');
+                        const fileDetail = issue.file ? '<span class="issue-file">' + escapeHtml(issue.file) + '</span>' : '';
+                        const fileMarkup = fileDetail ? ' ' + fileDetail : '';
+                        const issueIdValue = issue.id === undefined || issue.id === null
+                            ? ''
+                            : issue.id.toString();
+                        const fixButton = issue.autoFixable && issueIdValue
+                            ? '<button class="btn btn-small" type="button" data-action="fix-issue" data-issue-id="' + escapeHtml(issueIdValue) + '">Fix</button>'
+                            : '';
+
+                        let row = '<li class="issue-item">' +
+                            '<span class="issue-icon">' + getSeverityIcon(issue.severity) + '</span>' +
+                            '<span class="issue-text">' + message + fileMarkup + '</span>';
+
+                        if (fixButton) {
+                            row += fixButton;
+                        }
+
+                        row += '</li>';
+                        return row;
+                    }).join('');
+
+                    issuesList.innerHTML = issuesHtml;
                 }
+
+                wireDynamicActions(issuesList);
             } catch (error) {
                 console.error('Failed to load scan:', error);
+                const scan = document.getElementById('security-scan');
+                if (scan) {
+                    scan.className = '';
+                    scan.innerHTML = '<div class="metric">' +
+                        '<span class="metric-label text-danger">Scan unavailable</span>' +
+                        '<span class="metric-value">' + escapeHtml(error.message) + '</span>' +
+                    '</div>';
+                }
+
+                const badge = document.getElementById('status-badge');
+                if (badge) {
+                    badge.className = 'status-badge status-warning';
+                    badge.textContent = 'Scan Unavailable';
+                }
             }
         }
 
         async function loadGitStatus() {
             try {
-                const res = await fetch('/api/git-status');
-                const data = await res.json();
+                const res = await fetch('/api/git-status', {
+                    credentials: 'same-origin'
+                });
+                const data = await parseJsonResponse(res);
 
                 const gitStatus = document.getElementById('git-status');
                 gitStatus.className = '';
 
                 if (data.error) {
-                    gitStatus.innerHTML = '<p class="metric-label">' + data.error + '</p>';
+                    gitStatus.innerHTML = '<p class="metric-label">' + escapeHtml(data.error) + '</p>';
                     return;
                 }
 
-                gitStatus.innerHTML = \`
-                    <div class="metric">
-                        <span class="metric-label">Current Branch</span>
-                        <span class="metric-value">\${data.branch}</span>
-                    </div>
-                    <div class="metric">
-                        <span class="metric-label">Uncommitted Files</span>
-                        <span class="metric-value">\${data.status.length}</span>
-                    </div>
-                    <div class="metric">
-                        <span class="metric-label">Recent Commits</span>
-                        <span class="metric-value">\${data.commits.length}</span>
-                    </div>
-                \`;
+                const branch = escapeHtml(data.branch || 'unknown');
+                const uncommitted = escapeHtml((data.status || []).length);
+                const commits = escapeHtml((data.commits || []).length);
+
+                gitStatus.innerHTML = '<div class="metric">' +
+                    '<span class="metric-label">Current Branch</span>' +
+                    '<span class="metric-value">' + branch + '</span>' +
+                '</div>' +
+                '<div class="metric">' +
+                    '<span class="metric-label">Uncommitted Files</span>' +
+                    '<span class="metric-value">' + uncommitted + '</span>' +
+                '</div>' +
+                '<div class="metric">' +
+                    '<span class="metric-label">Recent Commits</span>' +
+                    '<span class="metric-value">' + commits + '</span>' +
+                '</div>';
             } catch (error) {
                 console.error('Failed to load git status:', error);
             }
@@ -886,55 +1528,85 @@ class DashboardServer {
 
         async function loadTools() {
             try {
-                const res = await fetch('/api/tools');
-                const data = await res.json();
+                const res = await fetch('/api/tools', {
+                    credentials: 'same-origin'
+                });
+                const data = await parseJsonResponse(res);
 
                 const toolsList = document.getElementById('tools-list');
                 toolsList.className = '';
 
-                const cloud = data.detected.filter(t => t.category === 'cloud');
-                const missing = data.missing;
+                const detected = Array.isArray(data.detected) ? data.detected : [];
+                const missingTools = Array.isArray(data.missing) ? data.missing : [];
+                const recommendations = Array.isArray(data.recommendations) ? data.recommendations : [];
 
-                toolsList.innerHTML = \`
-                    <h3 style="margin-bottom: 15px;">Detected Cloud Providers</h3>
-                    <ul class="tool-list">
-                        \${cloud.length > 0 ? cloud.map(t => \`
-                            <li class="tool-item">
-                                <span>\${t.provider}</span>
-                                <span class="tool-installed">✓ Detected</span>
-                            </li>
-                        \`).join('') : '<li class="tool-item"><span>No cloud providers detected</span></li>'}
-                    </ul>
+                const cloud = detected.filter(t => t.category === 'cloud');
 
-                    \${missing.length > 0 ? \`
-                        <h3 style="margin: 20px 0 15px;">Missing Tools</h3>
-                        <ul class="tool-list">
-                            \${missing.map(t => \`
-                                <li class="tool-item">
-                                    <div>
-                                        <div>\${t.name}</div>
-                                        <div style="font-size: 12px; color: #666;">\${t.reason}</div>
-                                    </div>
-                                    <button class="btn btn-small" onclick="installTool('\${t.name}', '\${t.install}')">Install</button>
-                                </li>
-                            \`).join('')}
-                        </ul>
-                    \` : ''}
+                const cloudHtml = cloud.length > 0
+                    ? cloud.map(t => {
+                        return '<li class="tool-item">' +
+                            '<span>' + escapeHtml(t.provider || 'Provider') + '</span>' +
+                            '<span class="tool-installed">✓ Detected</span>' +
+                        '</li>';
+                    }).join('')
+                    : '<li class="tool-item"><span>No cloud providers detected</span></li>';
 
-                    \${data.recommendations.length > 0 ? \`
-                        <h3 style="margin: 20px 0 15px;">Recommendations</h3>
-                        <ul class="tool-list">
-                            \${data.recommendations.map(r => \`
-                                <li class="tool-item">
-                                    <div>
-                                        <div>\${r.category}: \${r.type}</div>
-                                        <div style="font-size: 12px; color: #666;">\${r.reason}</div>
-                                    </div>
-                                </li>
-                            \`).join('')}
-                        </ul>
-                    \` : ''}
-                \`;
+                let missingHtml = '';
+                if (missingTools.length > 0) {
+                    missingHtml += '<h3 class="section-title">Missing Tools</h3>';
+                    missingHtml += '<ul class="tool-list">';
+                    missingHtml += missingTools.map(t => {
+                        const label = t.name || t.cli || t.command || t.provider || 'Tool';
+                        const reason = t.reason ? escapeHtml(t.reason) : '';
+                        const description = t.installerDescription ? ' — ' + escapeHtml(t.installerDescription) : '';
+                        const docsUrl = typeof t.docs === 'string' && /^https?:\/\//i.test(t.docs) ? t.docs : null;
+                        const docsLink = docsUrl
+                            ? '<div class="tool-doc-link"><a href="' + escapeHtml(docsUrl) + '" target="_blank" rel="noopener noreferrer">View docs</a></div>'
+                            : '';
+
+                        const safeInstallerId = typeof t.safeInstallerId === 'string' ? t.safeInstallerId : '';
+                        const installButton = safeInstallerId
+                            ? '<button class="btn btn-small" type="button" data-action="install-tool" data-tool-id="' + escapeHtml(safeInstallerId) + '" data-tool-name="' + escapeHtml(label) + '">Install</button>'
+                            : '<span class="tool-install-warning">Manual install required</span>';
+
+                        return '<li class="tool-item">' +
+                            '<div>' +
+                                '<div>' + escapeHtml(label) + '</div>' +
+                                '<div class="tool-meta">' + reason + description + '</div>' +
+                                docsLink +
+                            '</div>' +
+                            installButton +
+                        '</li>';
+                    }).join('');
+                    missingHtml += '</ul>';
+                }
+
+                let recommendationsHtml = '';
+                if (recommendations.length > 0) {
+                    recommendationsHtml += '<h3 class="section-title">Recommendations</h3>';
+                    recommendationsHtml += '<ul class="tool-list">';
+                    recommendationsHtml += recommendations.map(r => {
+                        const category = escapeHtml(r.category || 'Recommendation');
+                        const type = escapeHtml(r.type || 'Suggestion');
+                        const reason = escapeHtml(r.reason || '');
+                        return '<li class="tool-item">' +
+                            '<div>' +
+                                '<div>' + category + ': ' + type + '</div>' +
+                                '<div class="tool-meta">' + reason + '</div>' +
+                            '</div>' +
+                        '</li>';
+                    }).join('');
+                    recommendationsHtml += '</ul>';
+                }
+
+                toolsList.innerHTML = '<h3 class="section-title section-title--compact">Detected Cloud Providers</h3>' +
+                    '<ul class="tool-list">' +
+                        cloudHtml +
+                    '</ul>' +
+                    missingHtml +
+                    recommendationsHtml;
+
+                wireDynamicActions(toolsList);
             } catch (error) {
                 console.error('Failed to load tools:', error);
             }
@@ -954,31 +1626,46 @@ class DashboardServer {
             try {
                 const res = await fetch('/api/fix', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ issueId })
+                    headers: getJsonHeaders(),
+                    body: JSON.stringify({ issueId }),
+                    credentials: 'same-origin'
                 });
-                const result = await res.json();
-                alert(result.message);
+                const result = await parseJsonResponse(res);
+                alert(result.message || 'Issue fixed successfully.');
                 loadSecurityScan(); // Refresh
             } catch (error) {
                 alert('Failed to fix issue: ' + error.message);
             }
         }
 
-        async function installTool(name, command) {
-            if (confirm(\`Install \${name}?\\n\\nCommand: \${command}\`)) {
-                try {
-                    const res = await fetch('/api/install-tool', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ tool: name, command })
-                    });
-                    const result = await res.json();
-                    alert(result.message);
-                    loadTools(); // Refresh
-                } catch (error) {
-                    alert('Failed to install: ' + error.message);
+        async function installTool(toolId, toolName) {
+            if (!toolId) {
+                alert('Manual installation required. Please follow the documentation for this tool.');
+                return;
+            }
+
+            const nameLabel = toolName || 'tool';
+            if (!confirm('Install ' + nameLabel + '?')) {
+                return;
+            }
+
+            try {
+                const res = await fetch('/api/install-tool', {
+                    method: 'POST',
+                    headers: getJsonHeaders(),
+                    body: JSON.stringify({ toolId }),
+                    credentials: 'same-origin'
+                });
+                const result = await parseJsonResponse(res);
+
+                if (!result.success) {
+                    throw new Error(result.message || 'Installation failed.');
                 }
+
+                alert(result.message || (nameLabel + ' installed successfully.'));
+                loadTools(); // Refresh
+            } catch (error) {
+                alert('Failed to install ' + nameLabel + ': ' + error.message);
             }
         }
 
@@ -986,11 +1673,11 @@ class DashboardServer {
             const chat = document.getElementById('chat-container');
             const fab = document.querySelector('.chat-fab');
             chat.classList.toggle('open');
-            fab.style.display = chat.classList.contains('open') ? 'none' : 'block';
+            fab.classList.toggle('is-hidden', chat.classList.contains('open'));
         }
 
         function handleChatKeypress(event) {
-            if (event.key === 'Enter') {
+            if (event.key === 'Enter' && !event.shiftKey) {
                 sendChatMessage();
             }
         }
@@ -1003,25 +1690,29 @@ class DashboardServer {
             const messagesDiv = document.getElementById('chat-messages');
 
             // Add user message
-            messagesDiv.innerHTML += \`<div class="message message-user">\${message}</div>\`;
+            messagesDiv.innerHTML += '<div class="message message-user">' + formatMultiline(message) + '</div>';
             input.value = '';
             messagesDiv.scrollTop = messagesDiv.scrollHeight;
 
             try {
                 const res = await fetch('/api/chat', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ message })
+                    headers: getJsonHeaders(),
+                    body: JSON.stringify({ message }),
+                    credentials: 'same-origin'
                 });
-                const data = await res.json();
+                const data = await parseJsonResponse(res);
 
                 // Add AI response
-                messagesDiv.innerHTML += \`<div class="message message-ai">\${data.response}</div>\`;
+                const responseText = data && data.response ? formatMultiline(data.response) : 'No response available.';
+                messagesDiv.innerHTML += '<div class="message message-ai">' + responseText + '</div>';
                 messagesDiv.scrollTop = messagesDiv.scrollHeight;
             } catch (error) {
-                messagesDiv.innerHTML += \`<div class="message message-ai">Sorry, I encountered an error: \${error.message}</div>\`;
+                messagesDiv.innerHTML += '<div class="message message-ai">Sorry, I encountered an error: ' + escapeHtml(error.message) + '</div>';
             }
         }
+
+        wireStaticEventHandlers();
 
         // Load dashboard on page load
         loadDashboard();

--- a/guardian-engine.js
+++ b/guardian-engine.js
@@ -10,6 +10,7 @@ const { execSync } = require('child_process');
 const AIAssistant = require('./ai-assistant');
 const DockerValidator = require('./validators/docker-validator');
 const FirebaseValidator = require('./validators/firebase-validator');
+const { normalizeExperienceLevel } = require('./lib/config-service');
 
 class GuardianEngine {
     constructor(projectPath = process.cwd(), config = {}) {
@@ -20,12 +21,19 @@ class GuardianEngine {
         this.warnings = [];
         this.insights = [];
 
+        this.config.experienceLevel = normalizeExperienceLevel(this.config.experienceLevel || this.config.experience);
+        delete this.config.experience;
+        const claudeApiKey = this.config.claudeApiKey || process.env.CLAUDE_API_KEY;
+        const geminiApiKey = this.config.geminiApiKey || process.env.GEMINI_API_KEY;
+        this.config.claudeApiKey = claudeApiKey;
+        this.config.geminiApiKey = geminiApiKey;
+
         // Initialize AI Assistant
         this.ai = new AIAssistant({
-            claudeApiKey: config.claudeApiKey,
-            geminiApiKey: config.geminiApiKey,
-            experienceLevel: config.experienceLevel || 'beginner',
-            preferredProvider: config.preferredProvider
+            claudeApiKey,
+            geminiApiKey,
+            experienceLevel: this.config.experienceLevel,
+            preferredProvider: this.config.preferredProvider
         });
     }
 

--- a/guardian-test-report.json
+++ b/guardian-test-report.json
@@ -1,43 +1,26 @@
 {
-  "timestamp": "2025-09-30T13:09:57.848Z",
+  "timestamp": "2025-10-07T13:33:42.374Z",
   "project": "intelligent-cloud-guardian",
   "security": {
     "critical": 0,
-    "high": 1,
-    "medium": 1,
+    "high": 0,
+    "medium": 0,
     "warnings": 3,
-    "issues": [
-      {
-        "id": "gitignore-missing",
-        "severity": "HIGH",
-        "category": "Security",
-        "message": ".gitignore missing critical patterns",
-        "details": [
-          ".env.*",
-          "*.env",
-          "dist/",
-          "build/",
-          "logs/",
-          "serviceAccountKey.json",
-          "*credentials*.json",
-          "*.pem",
-          "*.key"
-        ],
-        "autoFixable": true,
-        "needsExplanation": false
-      },
-      {
-        "id": "no-env-example",
-        "severity": "MEDIUM",
-        "category": "Documentation",
-        "message": "Missing .env.example for team reference",
-        "autoFixable": true,
-        "needsExplanation": false
-      }
-    ]
+    "issues": []
   },
   "tools": {
     "detected": [
+      {
+        "category": "cloud",
+        "provider": "firebase",
+        "file": "firebase.json",
+        "cliRequired": {
+          "name": "firebase-tools",
+          "command": "firebase",
+          "install": "npm install -g firebase-tools",
+          "docs": "https://firebase.google.com/docs/cli"
+        }
+      },
       {
         "category": "vcs",
         "name": "git",
@@ -52,27 +35,47 @@
         "category": "package-manager",
         "name": "npm",
         "installed": true
-      },
-      {
-        "category": "containerization",
-        "name": "docker",
-        "installed": true
-      },
-      {
-        "category": "github-cli",
-        "name": "gh",
-        "installed": true
       }
     ],
-    "missing": [],
+    "missing": [
+      {
+        "id": "firebase-tools",
+        "category": "cli",
+        "provider": "firebase",
+        "cli": "firebase-tools",
+        "name": "firebase-tools",
+        "command": "firebase",
+        "install": "npm install -g firebase-tools",
+        "docs": "https://firebase.google.com/docs/cli",
+        "reason": "firebase detected but CLI not installed"
+      },
+      {
+        "id": "docker",
+        "category": "containerization",
+        "name": "docker",
+        "reason": "docker is required but not installed"
+      }
+    ],
     "recommendations": [
       {
         "category": "testing",
-        "type": "setup",
-        "priority": "high",
-        "reason": "No testing setup detected",
-        "suggestion": "Add testing to ensure code quality",
-        "autoSetup": true
+        "type": "framework",
+        "reason": "Found test directory but no testing framework",
+        "suggestion": "Install a testing framework",
+        "options": [
+          {
+            "name": "jest",
+            "install": "npm install --save-dev jest"
+          },
+          {
+            "name": "vitest",
+            "install": "npm install --save-dev vitest"
+          },
+          {
+            "name": "mocha",
+            "install": "npm install --save-dev mocha chai"
+          }
+        ]
       },
       {
         "category": "cicd",

--- a/holographic-dashboard.html
+++ b/holographic-dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Guardian Dashboard - Holographic Interface</title>
+    <title>Nimbus Dashboard - Holographic Interface</title>
     <style>
         * {
             margin: 0;
@@ -276,6 +276,19 @@
             text-shadow: 0 0 10px rgba(120, 119, 198, 0.5);
         }
 
+        .metric-value--success {
+            color: #34d399;
+        }
+
+        .metric-value--caution {
+            color: #fbbf24;
+        }
+
+        .metric-value--grade {
+            color: #34d399;
+            font-size: 20px;
+        }
+
         .issue-list {
             list-style: none;
         }
@@ -546,7 +559,7 @@
 
     <div class="container">
         <div class="header shimmer">
-            <h1>🛡️ INTELLIGENT CLOUD GUARDIAN</h1>
+            <h1>🛡️ NIMBUS INTELLIGENT CLOUD</h1>
             <p>Holographic Security Interface • Real-time Project Analysis</p>
         </div>
 
@@ -584,15 +597,15 @@
                 <h2>🛡️ SECURITY SCAN</h2>
                 <div class="metric">
                     <span class="metric-label">🔴 Critical</span>
-                    <span class="metric-value" style="color: #34d399;">0</span>
+                    <span class="metric-value metric-value--success">0</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">🟠 High</span>
-                    <span class="metric-value" style="color: #fbbf24;">1</span>
+                    <span class="metric-value metric-value--caution">1</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">🟡 Medium</span>
-                    <span class="metric-value" style="color: #fbbf24;">1</span>
+                    <span class="metric-value metric-value--caution">1</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">⚪ Warnings</span>
@@ -605,23 +618,23 @@
                 <h2>🔧 TOOLS DETECTED</h2>
                 <div class="metric">
                     <span class="metric-label">✓ git</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
+                    <span class="metric-value metric-value--success">Installed</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">✓ node</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
+                    <span class="metric-value metric-value--success">Installed</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">✓ npm</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
+                    <span class="metric-value metric-value--success">Installed</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">✓ docker</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
+                    <span class="metric-value metric-value--success">Installed</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">✓ gh (GitHub CLI)</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
+                    <span class="metric-value metric-value--success">Installed</span>
                 </div>
             </div>
 
@@ -635,14 +648,14 @@
                             <strong>HIGH:</strong> .gitignore missing critical patterns
                             <small>Missing: .env.*, *.env, dist/, logs/, *.pem, *.key</small>
                         </div>
-                        <button class="btn" onclick="alert('Run: guardian fix\n\nThis will automatically add missing patterns to .gitignore')">FIX NOW</button>
+                        <button class="btn" data-fix-message="Run: nimbus fix&#10;&#10;This will automatically add missing patterns to .gitignore">FIX NOW</button>
                     </li>
                     <li class="issue-item">
                         <span class="issue-icon">🟡</span>
                         <div class="issue-text">
                             <strong>MEDIUM:</strong> Missing .env.example for team reference
                         </div>
-                        <button class="btn" onclick="alert('Run: guardian fix\n\nThis will create a template .env.example file')">FIX NOW</button>
+                        <button class="btn" data-fix-message="Run: nimbus fix&#10;&#10;This will create a template .env.example file">FIX NOW</button>
                     </li>
                     <li class="issue-item">
                         <span class="issue-icon">💡</span>
@@ -670,9 +683,9 @@
 
             <!-- Test Results -->
             <div class="card full-width depth-layer-3">
-                <h2>✅ GUARDIAN SELF-TEST RESULTS</h2>
+                <h2>✅ NIMBUS SELF-TEST RESULTS</h2>
                 <div class="success-icon">🎉</div>
-                <p class="success-text">GUARDIAN WORKS PERFECTLY!</p>
+                <p class="success-text">NIMBUS WORKS PERFECTLY!</p>
                 <div class="metric">
                     <span class="metric-label">Scan Speed</span>
                     <span class="metric-value">15 seconds ⚡</span>
@@ -687,7 +700,7 @@
                 </div>
                 <div class="metric">
                     <span class="metric-label">Overall Grade</span>
-                    <span class="metric-value" style="color: #34d399; font-size: 20px;">A-</span>
+                    <span class="metric-value metric-value--grade">A-</span>
                 </div>
                 <div class="alert-box">
                     <strong>✅ PRODUCT IS READY FOR BETA USERS!</strong>
@@ -699,7 +712,7 @@
             <div class="card full-width depth-layer-1">
                 <h2>🚀 NEXT STEPS</h2>
                 <ol>
-                    <li><strong>Run auto-fixes:</strong> <code>guardian fix</code></li>
+                    <li><strong>Run auto-fixes:</strong> <code>nimbus fix</code></li>
                     <li><strong>Add testing:</strong> <code>npm install --save-dev jest</code></li>
                     <li><strong>Setup CI/CD:</strong> Create .github/workflows/test.yml</li>
                     <li><strong>Test with real users:</strong> Share with 20 developers for beta testing</li>
@@ -710,9 +723,19 @@
     </div>
 
     <script>
-        console.log('🛡️ Guardian Holographic Interface Loaded');
+        console.log('🛡️ Nimbus Holographic Interface Loaded');
         console.log('🎨 Glassmorphism + Holographic Effects Active');
         console.log('✨ This is the future of deployment monitoring');
+
+        const fixButtons = document.querySelectorAll('[data-fix-message]');
+        fixButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                const message = button.getAttribute('data-fix-message');
+                if (message) {
+                    alert(message);
+                }
+            });
+        });
 
         // Add subtle mouse parallax effect to cards
         document.addEventListener('mousemove', (e) => {

--- a/lib/config-service.js
+++ b/lib/config-service.js
@@ -1,0 +1,177 @@
+const fs = require('fs-extra');
+const path = require('path');
+const dotenv = require('dotenv');
+
+const VALID_EXPERIENCE_LEVELS = new Set(['beginner', 'intermediate', 'advanced']);
+const loadedEnvFiles = new Set();
+
+function getConfigPaths(projectPath = process.cwd()) {
+    const configDir = path.join(projectPath, '.guardian');
+    return {
+        projectPath,
+        configDir,
+        configPath: path.join(configDir, 'config.json'),
+        envPath: path.join(configDir, '.env')
+    };
+}
+
+function sanitizeConfigInput(data = {}) {
+    const sanitized = { ...data };
+    delete sanitized.claudeApiKey;
+    delete sanitized.geminiApiKey;
+    return sanitized;
+}
+
+function normalizeExperienceLevel(value) {
+    if (!value) {
+        return 'intermediate';
+    }
+
+    const normalized = value.toString().trim().toLowerCase();
+    return VALID_EXPERIENCE_LEVELS.has(normalized) ? normalized : 'intermediate';
+}
+
+function normalizeConfigData(raw = {}, projectPath) {
+    const sanitized = sanitizeConfigInput(raw);
+    const normalized = { ...sanitized };
+    let changed = false;
+
+    if (normalized.experienceLevel) {
+        const experienceLevel = normalizeExperienceLevel(normalized.experienceLevel);
+        if (experienceLevel !== normalized.experienceLevel) {
+            normalized.experienceLevel = experienceLevel;
+            changed = true;
+        }
+    } else if (raw.experience || normalized.experience) {
+        const legacyValue = raw.experience ?? normalized.experience;
+        normalized.experienceLevel = normalizeExperienceLevel(legacyValue);
+        delete normalized.experience;
+        changed = true;
+    } else {
+        normalized.experienceLevel = 'intermediate';
+        changed = true;
+    }
+
+    if (!normalized.projectName && projectPath) {
+        normalized.projectName = path.basename(projectPath);
+        changed = true;
+    }
+
+    return { config: normalized, changed };
+}
+
+async function loadEnvironment(projectPath) {
+    const { envPath } = getConfigPaths(projectPath);
+
+    if (!(await fs.pathExists(envPath))) {
+        return {};
+    }
+
+    if (!loadedEnvFiles.has(envPath)) {
+        dotenv.config({ path: envPath });
+        loadedEnvFiles.add(envPath);
+    }
+
+    try {
+        const contents = await fs.readFile(envPath);
+        return dotenv.parse(contents);
+    } catch {
+        return {};
+    }
+}
+
+async function loadConfig(projectPath = process.cwd(), options = {}) {
+    const { createIfMissing = false } = options;
+    const { configPath, configDir } = getConfigPaths(projectPath);
+
+    const { config: existingConfig, corruptedBackupPath } = await safeReadConfig(configPath);
+
+    let rawConfig = existingConfig;
+
+    if (rawConfig) {
+        // already have the parsed config
+    } else if (createIfMissing) {
+        rawConfig = {};
+        await fs.ensureDir(configDir);
+    } else {
+        await loadEnvironment(projectPath);
+        return null;
+    }
+
+    const { config: normalized, changed } = normalizeConfigData(rawConfig, projectPath);
+
+    if (changed) {
+        await fs.writeJson(configPath, normalized, { spaces: 2 });
+    }
+
+    const envValues = await loadEnvironment(projectPath);
+    const meta = {
+        warnings: [],
+        corruptedBackupPath
+    };
+
+    if (corruptedBackupPath) {
+        meta.warnings.push(
+            `Recovered from corrupted config.json; original moved to ${path.basename(corruptedBackupPath)}`
+        );
+    }
+
+    Object.defineProperty(normalized, '__meta', {
+        value: meta,
+        enumerable: false,
+        configurable: false,
+        writable: false
+    });
+
+    const result = {
+        ...normalized,
+        claudeApiKey: normalized.claudeApiKey || envValues.CLAUDE_API_KEY || process.env.CLAUDE_API_KEY,
+        geminiApiKey: normalized.geminiApiKey || envValues.GEMINI_API_KEY || process.env.GEMINI_API_KEY
+    };
+
+    Object.defineProperty(result, '__meta', {
+        value: meta,
+        enumerable: false,
+        configurable: false,
+        writable: false
+    });
+
+    return result;
+}
+
+async function safeReadConfig(configPath) {
+    if (!(await fs.pathExists(configPath))) {
+        return { config: null, corruptedBackupPath: null };
+    }
+
+    try {
+        return { config: await fs.readJson(configPath), corruptedBackupPath: null };
+    } catch (error) {
+        if (error instanceof SyntaxError || error.name === 'SyntaxError') {
+            const backupPath = `${configPath}.corrupted-${Date.now()}.json`;
+            await fs.move(configPath, backupPath, { overwrite: true });
+            return { config: {}, corruptedBackupPath: backupPath };
+        }
+        throw error;
+    }
+}
+
+async function saveConfig(projectPath = process.cwd(), data = {}) {
+    const { configPath, configDir } = getConfigPaths(projectPath);
+    await fs.ensureDir(configDir);
+
+    const { config: existing } = await safeReadConfig(configPath);
+    const merged = { ...(existing || {}), ...sanitizeConfigInput(data) };
+    const { config: normalized } = normalizeConfigData(merged, projectPath);
+
+    await fs.writeJson(configPath, normalized, { spaces: 2 });
+    return normalized;
+}
+
+module.exports = {
+    getConfigPaths,
+    loadConfig,
+    saveConfig,
+    loadEnvironment,
+    normalizeExperienceLevel
+};

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -1,175 +1,98 @@
-#!/usr/bin/env node
+'use strict';
 
-/**
- * Rate Limiter
- * Enforces usage limits based on license tier
- *
- * © 2025 Paul Phillips - Clear Seas Solutions LLC
- */
-
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const DEFAULT_MAX = 60;
 
 class RateLimiter {
-    constructor() {
-        this.configDir = path.join(os.homedir(), '.nimbus');
-        this.limitsFile = path.join(this.configDir, 'rate-limits.json');
+    constructor(options = {}) {
+        const {
+            windowMs = DEFAULT_WINDOW_MS,
+            max = DEFAULT_MAX,
+            now = () => Date.now()
+        } = options;
 
-        if (!fs.existsSync(this.configDir)) {
-            fs.mkdirSync(this.configDir, { recursive: true });
+        if (!Number.isFinite(windowMs) || windowMs <= 0) {
+            throw new Error('windowMs must be a positive number');
         }
+
+        if (!Number.isFinite(max) || max <= 0) {
+            throw new Error('max must be a positive number');
+        }
+
+        this.windowMs = windowMs;
+        this.max = Math.floor(max);
+        this.now = typeof now === 'function' ? now : () => Date.now();
+
+        this.buckets = new Map();
     }
 
-    /**
-     * Rate limit windows (in milliseconds)
-     */
-    WINDOWS = {
-        MINUTE: 60 * 1000,
-        HOUR: 60 * 60 * 1000,
-        DAY: 24 * 60 * 60 * 1000,
-        MONTH: 30 * 24 * 60 * 60 * 1000
-    };
-
-    /**
-     * Tier limits
-     */
-    LIMITS = {
-        FREE: {
-            scans: { perDay: 50, perHour: 10 },
-            ai: { perMonth: 0 }, // No AI on free tier
-            fixes: { perDay: 20 }
-        },
-        PRO: {
-            scans: { perDay: Infinity, perHour: Infinity },
-            ai: { perMonth: Infinity },
-            fixes: { perDay: Infinity }
-        },
-        ENTERPRISE: {
-            scans: { perDay: Infinity, perHour: Infinity },
-            ai: { perMonth: Infinity },
-            fixes: { perDay: Infinity }
-        }
-    };
-
-    /**
-     * Get current limits data
-     */
-    getLimitsData() {
-        if (!fs.existsSync(this.limitsFile)) {
-            return this.createEmptyLimits();
+    _getBucket(key, currentTime) {
+        const existing = this.buckets.get(key);
+        if (!existing) {
+            return null;
         }
 
-        try {
-            const data = fs.readFileSync(this.limitsFile, 'utf-8');
-            return JSON.parse(data);
-        } catch (err) {
-            return this.createEmptyLimits();
+        if (existing.expiresAt <= currentTime) {
+            this.buckets.delete(key);
+            return null;
         }
+
+        return existing;
     }
 
-    /**
-     * Create empty limits structure
-     */
-    createEmptyLimits() {
+    consume(key, weight = 1, currentTime = this.now()) {
+        if (!key) {
+            throw new Error('A key is required for rate limiting');
+        }
+
+        if (!Number.isFinite(weight) || weight <= 0) {
+            throw new Error('weight must be a positive number');
+        }
+
+        const normalizedWeight = Math.ceil(weight);
+        if (normalizedWeight > this.max) {
+            return {
+                allowed: false,
+                remaining: 0,
+                retryAfterMs: this.windowMs,
+                resetMs: currentTime + this.windowMs
+            };
+        }
+
+        const bucket = this._getBucket(key, currentTime) || {
+            count: 0,
+            expiresAt: currentTime + this.windowMs
+        };
+
+        if (bucket.count + normalizedWeight > this.max) {
+            const retryAfterMs = Math.max(0, bucket.expiresAt - currentTime);
+            return {
+                allowed: false,
+                remaining: Math.max(0, this.max - bucket.count),
+                retryAfterMs,
+                resetMs: bucket.expiresAt
+            };
+        }
+
+        bucket.count += normalizedWeight;
+        this.buckets.set(key, bucket);
+
         return {
-            scans: { timestamps: [] },
-            ai: { timestamps: [] },
-            fixes: { timestamps: [] }
+            allowed: true,
+            remaining: Math.max(0, this.max - bucket.count),
+            retryAfterMs: 0,
+            resetMs: bucket.expiresAt
         };
     }
 
-    /**
-     * Clean old timestamps outside the window
-     */
-    cleanTimestamps(timestamps, window) {
-        const now = Date.now();
-        return timestamps.filter(ts => now - ts < window);
+    reset(key) {
+        if (key) {
+            this.buckets.delete(key);
+        }
     }
 
-    /**
-     * Check if action is allowed
-     */
-    checkLimit(action, tier) {
-        const limits = this.LIMITS[tier] || this.LIMITS.FREE;
-        const data = this.getLimitsData();
-
-        if (!data[action]) {
-            data[action] = { timestamps: [] };
-        }
-
-        const actionLimits = limits[action];
-        if (!actionLimits) return { allowed: true };
-
-        // Check each limit type
-        for (const [period, limit] of Object.entries(actionLimits)) {
-            if (limit === Infinity) continue;
-
-            const window = this.WINDOWS[period.replace('per', '').toUpperCase()];
-            const recentTimestamps = this.cleanTimestamps(data[action].timestamps, window);
-
-            if (recentTimestamps.length >= limit) {
-                return {
-                    allowed: false,
-                    reason: `Rate limit exceeded: ${limit} ${action}s ${period}`,
-                    resetAt: new Date(Math.min(...recentTimestamps) + window).toISOString(),
-                    upgrade: 'https://nimbus-guardian.web.app/#pricing'
-                };
-            }
-        }
-
-        return { allowed: true };
-    }
-
-    /**
-     * Record action
-     */
-    recordAction(action) {
-        const data = this.getLimitsData();
-
-        if (!data[action]) {
-            data[action] = { timestamps: [] };
-        }
-
-        data[action].timestamps.push(Date.now());
-
-        // Clean old timestamps to keep file size manageable
-        const oneMonthAgo = Date.now() - this.WINDOWS.MONTH;
-        data[action].timestamps = data[action].timestamps.filter(ts => ts > oneMonthAgo);
-
-        fs.writeFileSync(this.limitsFile, JSON.stringify(data, null, 2));
-    }
-
-    /**
-     * Get usage in current period
-     */
-    getUsage(action, period, tier) {
-        const data = this.getLimitsData();
-
-        if (!data[action]) return { used: 0, limit: 0 };
-
-        const window = this.WINDOWS[period.toUpperCase()];
-        const recentTimestamps = this.cleanTimestamps(data[action].timestamps, window);
-
-        const limits = this.LIMITS[tier] || this.LIMITS.FREE;
-        const limit = limits[action]?.[`per${period.charAt(0).toUpperCase() + period.slice(1)}`] || Infinity;
-
-        return {
-            used: recentTimestamps.length,
-            limit: limit === Infinity ? '∞' : limit,
-            resetAt: recentTimestamps.length > 0
-                ? new Date(Math.min(...recentTimestamps) + window).toISOString()
-                : null
-        };
-    }
-
-    /**
-     * Reset all limits (admin function)
-     */
-    reset() {
-        if (fs.existsSync(this.limitsFile)) {
-            fs.unlinkSync(this.limitsFile);
-        }
+    resetAll() {
+        this.buckets.clear();
     }
 }
 

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const crypto = require('crypto');
+
+class SessionManager {
+    constructor(options = {}) {
+        const {
+            ttlMs = 1000 * 60 * 60 * 12, // 12 hours
+            cleanupIntervalMs = 1000 * 60 * 10, // 10 minutes
+            idGenerator = () => crypto.randomBytes(18).toString('hex'),
+            tokenGenerator = () => crypto.randomBytes(32).toString('hex'),
+            now = () => Date.now()
+        } = options;
+
+        this.ttlMs = ttlMs;
+        this.cleanupIntervalMs = cleanupIntervalMs;
+        this.idGenerator = idGenerator;
+        this.tokenGenerator = tokenGenerator;
+        this.now = now;
+
+        this.sessions = new Map();
+        this.lastCleanup = 0;
+    }
+
+    cleanupExpiredSessions(currentTime = this.now()) {
+        if (this.cleanupIntervalMs <= 0) {
+            return;
+        }
+
+        if (currentTime - this.lastCleanup < this.cleanupIntervalMs) {
+            return;
+        }
+
+        for (const [id, session] of this.sessions.entries()) {
+            if (session.lastSeen + this.ttlMs <= currentTime) {
+                this.sessions.delete(id);
+            }
+        }
+
+        this.lastCleanup = currentTime;
+    }
+
+    createSession() {
+        const session = this._buildSession();
+        this.sessions.set(session.id, session);
+        this.cleanupExpiredSessions(session.createdAt);
+        return session;
+    }
+
+    _buildSession() {
+        const timestamp = this.now();
+        return {
+            id: this.idGenerator(),
+            csrfToken: this.tokenGenerator(),
+            createdAt: timestamp,
+            lastSeen: timestamp
+        };
+    }
+
+    getSession(sessionId) {
+        if (!sessionId) {
+            return null;
+        }
+
+        const session = this.sessions.get(sessionId);
+        if (!session) {
+            return null;
+        }
+
+        const currentTime = this.now();
+        if (session.lastSeen + this.ttlMs <= currentTime) {
+            this.sessions.delete(sessionId);
+            return null;
+        }
+
+        return session;
+    }
+
+    touchSession(sessionId, options = {}) {
+        const session = this.getSession(sessionId);
+        if (!session) {
+            return null;
+        }
+
+        const { rotateCsrf = false } = options;
+        const currentTime = this.now();
+        session.lastSeen = currentTime;
+
+        if (rotateCsrf) {
+            session.csrfToken = this.tokenGenerator();
+        }
+
+        this.sessions.set(sessionId, session);
+        this.cleanupExpiredSessions(currentTime);
+        return session;
+    }
+}
+
+module.exports = SessionManager;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "node cli.js",
     "setup": "node setup.js",
-    "chat": "node chat-assistant.js"
+    "chat": "node chat-assistant.js",
+    "test": "node --test"
   },
   "keywords": [
     "deployment",

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -126,6 +126,32 @@
             font-size: 18px;
         }
 
+        .config-alert {
+            margin-top: 16px;
+            padding: 14px 16px;
+            border-radius: 14px;
+            background: rgba(255, 193, 7, 0.18);
+            border: 1px solid rgba(255, 193, 7, 0.45);
+            color: #f0c419;
+            font-size: 14px;
+            line-height: 1.5;
+        }
+
+        .config-alert.hidden {
+            display: none;
+        }
+
+        .config-alert strong {
+            display: block;
+            margin-bottom: 8px;
+            color: #ffe08a;
+        }
+
+        .config-alert ul {
+            margin-left: 18px;
+            margin-bottom: 0;
+        }
+
         .grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
@@ -276,6 +302,19 @@
             text-shadow: 0 0 10px rgba(120, 119, 198, 0.5);
         }
 
+        .metric-value--success {
+            color: #34d399;
+        }
+
+        .metric-value--caution {
+            color: #fbbf24;
+        }
+
+        .metric-value--grade {
+            color: #34d399;
+            font-size: 20px;
+        }
+
         .issue-list {
             list-style: none;
         }
@@ -337,6 +376,56 @@
             color: rgba(255, 255, 255, 0.5);
             display: block;
             margin-top: 4px;
+        }
+
+        .tool-list {
+            list-style: none;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .tool-chip {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 10px;
+            padding: 12px 16px;
+            transition: transform 0.3s, border-color 0.3s;
+        }
+
+        .tool-chip:hover {
+            transform: translateX(5px);
+            border-color: rgba(255, 255, 255, 0.3);
+        }
+
+        .tool-chip .tool-name {
+            font-weight: 600;
+            color: #fff;
+        }
+
+        .tool-chip .tool-status {
+            font-weight: 500;
+            color: #34d399;
+        }
+
+        .tool-chip.missing {
+            background: rgba(255, 153, 0, 0.1);
+            border-color: rgba(255, 153, 0, 0.4);
+        }
+
+        .tool-chip.missing .tool-status {
+            color: #f59e0b;
+        }
+
+        .tool-chip small {
+            display: block;
+            margin-top: 4px;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 12px;
         }
 
         .btn {
@@ -548,6 +637,7 @@
         <div class="header shimmer">
             <h1>☁️ NIMBUS</h1>
             <p>Holographic Security Interface • Real-time Project Analysis</p>
+            <div class="config-alert hidden" data-field="config-warnings"></div>
         </div>
 
         <div class="grid">
@@ -555,27 +645,27 @@
             <div class="card depth-layer-1">
                 <h2>
                     📊 PROJECT STATUS
-                    <span class="status-badge status-warning">Issues Detected</span>
+                    <span class="status-badge status-warning" data-field="status-badge">Issues Detected</span>
                 </h2>
                 <div class="metric">
                     <span class="metric-label">Project Name</span>
-                    <span class="metric-value">Nimbus</span>
+                    <span class="metric-value" data-field="project-name">Nimbus</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">Experience Level</span>
-                    <span class="metric-value">Advanced</span>
+                    <span class="metric-value" data-field="experience-level">Advanced</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">Dependencies</span>
-                    <span class="metric-value">12</span>
+                    <span class="metric-value" data-field="dependency-count">12</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">Dev Dependencies</span>
-                    <span class="metric-value">1</span>
+                    <span class="metric-value" data-field="dev-dependency-count">1</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">Git Branch</span>
-                    <span class="metric-value">main</span>
+                    <span class="metric-value" data-field="git-branch">main</span>
                 </div>
             </div>
 
@@ -584,87 +674,35 @@
                 <h2>🛡️ SECURITY SCAN</h2>
                 <div class="metric">
                     <span class="metric-label">🔴 Critical</span>
-                    <span class="metric-value" style="color: #34d399;">0</span>
+                    <span class="metric-value metric-value--success" data-field="scan-critical">0</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">🟠 High</span>
-                    <span class="metric-value" style="color: #fbbf24;">1</span>
+                    <span class="metric-value metric-value--caution" data-field="scan-high">1</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">🟡 Medium</span>
-                    <span class="metric-value" style="color: #fbbf24;">1</span>
+                    <span class="metric-value metric-value--caution" data-field="scan-medium">1</span>
                 </div>
                 <div class="metric">
                     <span class="metric-label">⚪ Warnings</span>
-                    <span class="metric-value">3</span>
+                    <span class="metric-value" data-field="scan-warnings">3</span>
                 </div>
             </div>
 
             <!-- Tools Detected -->
             <div class="card depth-layer-1">
                 <h2>🔧 TOOLS DETECTED</h2>
-                <div class="metric">
-                    <span class="metric-label">✓ git</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ node</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ npm</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ docker</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
-                </div>
-                <div class="metric">
-                    <span class="metric-label">✓ gh (GitHub CLI)</span>
-                    <span class="metric-value" style="color: #34d399;">Installed</span>
-                </div>
+                <ul class="tool-list" id="tool-list">
+                    <li class="metric">Loading tools…</li>
+                </ul>
             </div>
 
             <!-- Issues Found -->
             <div class="card full-width depth-layer-2">
                 <h2>⚠️ ISSUES & RECOMMENDATIONS</h2>
-                <ul class="issue-list">
-                    <li class="issue-item">
-                        <span class="issue-icon">🟠</span>
-                        <div class="issue-text">
-                            <strong>HIGH:</strong> .gitignore missing critical patterns
-                            <small>Missing: .env.*, *.env, dist/, logs/, *.pem, *.key</small>
-                        </div>
-                        <button class="btn" onclick="alert('Run: nimbus fix\n\nThis will automatically add missing patterns to .gitignore')">FIX NOW</button>
-                    </li>
-                    <li class="issue-item">
-                        <span class="issue-icon">🟡</span>
-                        <div class="issue-text">
-                            <strong>MEDIUM:</strong> Missing .env.example for team reference
-                        </div>
-                        <button class="btn" onclick="alert('Run: nimbus fix\n\nThis will create a template .env.example file')">FIX NOW</button>
-                    </li>
-                    <li class="issue-item">
-                        <span class="issue-icon">💡</span>
-                        <div class="issue-text">
-                            <strong>Recommendation:</strong> Add testing framework (Jest)
-                            <small>No testing setup detected - add tests to ensure code quality</small>
-                        </div>
-                    </li>
-                    <li class="issue-item">
-                        <span class="issue-icon">💡</span>
-                        <div class="issue-text">
-                            <strong>Recommendation:</strong> Setup CI/CD pipeline
-                            <small>Add GitHub Actions or GitLab CI for automated testing</small>
-                        </div>
-                    </li>
-                    <li class="issue-item">
-                        <span class="issue-icon">💡</span>
-                        <div class="issue-text">
-                            <strong>Recommendation:</strong> Add error monitoring
-                            <small>Install Sentry or Winston for production error tracking</small>
-                        </div>
-                    </li>
+                <ul class="issue-list" id="issue-list">
+                    <li class="issue-item">Loading recent scan results…</li>
                 </ul>
             </div>
 
@@ -687,7 +725,7 @@
                 </div>
                 <div class="metric">
                     <span class="metric-label">Overall Grade</span>
-                    <span class="metric-value" style="color: #34d399; font-size: 20px;">A-</span>
+                    <span class="metric-value metric-value--grade">A-</span>
                 </div>
                 <div class="alert-box">
                     <strong>✅ PRODUCT IS READY FOR BETA USERS!</strong>
@@ -714,75 +752,359 @@
         console.log('🎨 Glassmorphism + Holographic Effects Active');
         console.log('✨ This is the future of deployment monitoring');
 
-        // Firebase configuration
-        import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-app.js';
-        import { getFirestore, collection, doc, getDoc, getDocs, query, orderBy, limit } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore.js';
-        import { getAuth, signInAnonymously, onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/10.7.1/firebase-auth.js';
-
-        const firebaseConfig = {
-            apiKey: "AIzaSyCdJO1Y_s-s_phMrTmm6VDQG-pvNEtyPSI",
-            authDomain: "nimbus-guardian.firebaseapp.com",
-            projectId: "nimbus-guardian",
-            storageBucket: "nimbus-guardian.firebasestorage.app",
-            messagingSenderId: "672144468079",
-            appId: "1:672144468079:web:6e0fdc5736d9d27b13859a"
+        const fields = {
+            projectName: document.querySelector('[data-field="project-name"]'),
+            experienceLevel: document.querySelector('[data-field="experience-level"]'),
+            dependencyCount: document.querySelector('[data-field="dependency-count"]'),
+            devDependencyCount: document.querySelector('[data-field="dev-dependency-count"]'),
+            gitBranch: document.querySelector('[data-field="git-branch"]'),
+            configWarnings: document.querySelector('[data-field="config-warnings"]'),
+            statusBadge: document.querySelector('[data-field="status-badge"]'),
+            scanCritical: document.querySelector('[data-field="scan-critical"]'),
+            scanHigh: document.querySelector('[data-field="scan-high"]'),
+            scanMedium: document.querySelector('[data-field="scan-medium"]'),
+            scanWarnings: document.querySelector('[data-field="scan-warnings"]')
         };
 
-        const app = initializeApp(firebaseConfig);
-        const db = getFirestore(app);
-        const auth = getAuth(app);
+        function updateCsrfTokenFromResponse(response) {
+            if (!response || typeof response.headers?.get !== 'function') {
+                return;
+            }
 
-        // Auto sign-in anonymously for demo
-        signInAnonymously(auth);
+            const nextToken = response.headers.get('X-CSRF-Token');
+            if (!nextToken || typeof nextToken !== 'string') {
+                return;
+            }
 
-        // Load real data from Firestore
-        async function loadRealData() {
-            try {
-                // Get user account (replace with actual userId from CLI)
-                const userId = 'demo-user'; // TODO: Get from URL param or login
-                const userDoc = await getDoc(doc(db, 'users', userId));
+            const trimmed = nextToken.trim();
+            if (!trimmed || trimmed === window.__CSRF_TOKEN__) {
+                return;
+            }
 
-                if (userDoc.exists()) {
-                    const userData = userDoc.data();
-                    updateDashboard(userData);
+            window.__CSRF_TOKEN__ = trimmed;
+            const meta = document.querySelector('meta[name="csrf-token"]');
+            if (meta) {
+                meta.setAttribute('content', trimmed);
+            }
+        }
+
+        function getRetryAfterSeconds(response) {
+            if (!response || typeof response.headers?.get !== 'function') {
+                return null;
+            }
+
+            const retryAfter = response.headers.get('Retry-After');
+            if (!retryAfter) {
+                return null;
+            }
+
+            const seconds = Number.parseInt(retryAfter, 10);
+            return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+        }
+
+        function formatRateLimitMessage(response, baseMessage) {
+            const seconds = getRetryAfterSeconds(response);
+            if (!seconds) {
+                return baseMessage;
+            }
+
+            const unit = seconds === 1 ? 'second' : 'seconds';
+            return `${baseMessage} Try again in ${seconds} ${unit}.`;
+        }
+
+        function setField(name, value) {
+            const el = fields[name];
+            if (el) {
+                el.textContent = value ?? '—';
+            }
+        }
+
+        function setNumberField(name, value) {
+            setField(name, typeof value === 'number' ? value : '—');
+        }
+
+        function renderConfigWarnings(warnings) {
+            const container = fields.configWarnings;
+            if (!container) return;
+
+            const entries = Array.isArray(warnings) ? warnings.filter(Boolean) : [];
+
+            if (!entries.length) {
+                container.classList.add('hidden');
+                container.replaceChildren();
+                return;
+            }
+
+            container.classList.remove('hidden');
+            const title = document.createElement('strong');
+            title.textContent = entries.length > 1
+                ? 'Configuration warnings detected:'
+                : 'Configuration warning detected:';
+
+            const list = document.createElement('ul');
+            entries.forEach(entry => {
+                const item = document.createElement('li');
+                item.textContent = entry;
+                list.appendChild(item);
+            });
+
+            container.replaceChildren(title, list);
+        }
+
+        function applyStatus(status) {
+            renderConfigWarnings(status?.configWarnings);
+            if (!status) {
+                return;
+            }
+
+            setField('projectName', status.projectName || status.package?.name || 'Nimbus');
+            setField('experienceLevel', status.experienceLevel || '—');
+            setNumberField('dependencyCount', status.package?.dependencies);
+            setNumberField('devDependencyCount', status.package?.devDependencies);
+            setField('gitBranch', status.git?.branch || '—');
+        }
+
+        function applySecurity(report) {
+            const security = report?.security;
+            setNumberField('scanCritical', security?.critical);
+            setNumberField('scanHigh', security?.high);
+            setNumberField('scanMedium', security?.medium);
+            setNumberField('scanWarnings', security?.warnings);
+
+            const badge = fields.statusBadge;
+            if (!badge) return;
+
+            let text = 'Scan Pending';
+            let badgeClass = 'status-badge status-warning';
+
+            if (security) {
+                const critical = security.critical || 0;
+                const high = security.high || 0;
+                const medium = security.medium || 0;
+
+                if (critical > 0) {
+                    text = 'Critical Issues';
+                    badgeClass = 'status-badge status-error';
+                } else if (high > 0 || medium > 0) {
+                    text = 'Issues Detected';
+                    badgeClass = 'status-badge status-warning';
                 } else {
-                    console.log('No user data found - showing demo data');
-                    showDemoData();
+                    text = 'Healthy';
+                    badgeClass = 'status-badge status-good';
                 }
+            }
+
+            badge.textContent = text;
+            badge.className = badgeClass;
+        }
+
+        function renderTools(data) {
+            const list = document.getElementById('tool-list');
+            if (!list) return;
+
+            list.innerHTML = '';
+
+            const detected = Array.isArray(data?.detected) ? data.detected : [];
+            const missing = Array.isArray(data?.missing) ? data.missing : [];
+
+            if (!detected.length && !missing.length) {
+                const item = document.createElement('li');
+                item.className = 'tool-chip';
+                item.textContent = 'No tooling data available yet. Run “nimbus scan” to collect insights.';
+                list.appendChild(item);
+                return;
+            }
+
+            const addChip = (name, statusLabel, detail, options = {}) => {
+                const item = document.createElement('li');
+                item.className = 'tool-chip';
+                if (options.missing) {
+                    item.classList.add('missing');
+                }
+
+                const info = document.createElement('div');
+
+                const title = document.createElement('span');
+                title.className = 'tool-name';
+                title.textContent = name;
+                info.appendChild(title);
+
+                if (detail) {
+                    const detailEl = document.createElement('small');
+                    detailEl.textContent = detail;
+                    info.appendChild(detailEl);
+                }
+
+                const statusEl = document.createElement('span');
+                statusEl.className = 'tool-status';
+                statusEl.textContent = statusLabel;
+
+                item.appendChild(info);
+                item.appendChild(statusEl);
+                list.appendChild(item);
+            };
+
+            detected.slice(0, 8).forEach(tool => {
+                const name = tool.displayName || tool.name || tool.provider || tool.id || 'Detected Tool';
+                const detail = tool.category ? `${tool.category.toUpperCase()} toolkit` : '';
+                addChip(name, 'Installed', detail);
+            });
+
+            missing.slice(0, 8).forEach(tool => {
+                const name = tool.displayName || tool.name || tool.provider || tool.id || 'Missing Tool';
+                const detail = tool.install ? `Install: ${tool.install}` : tool.reason || 'Install required';
+                addChip(name, 'Missing', detail, { missing: true });
+            });
+        }
+
+        function severityIcon(level = '') {
+            const iconMap = {
+                CRITICAL: '🔴',
+                HIGH: '🟠',
+                MEDIUM: '🟡',
+                LOW: '⚪'
+            };
+            const normalized = String(level || '').toUpperCase();
+            return iconMap[normalized] || '💡';
+        }
+
+        function renderIssues(report) {
+            const list = document.getElementById('issue-list');
+            if (!list) return;
+
+            list.innerHTML = '';
+
+            const issues = Array.isArray(report?.security?.issues) ? report.security.issues : [];
+            const recommendations = Array.isArray(report?.tools?.recommendations) ? report.tools.recommendations : [];
+
+            if (!issues.length && !recommendations.length) {
+                const item = document.createElement('li');
+                item.className = 'issue-item';
+                item.textContent = 'Run “nimbus scan” to generate a detailed issue report.';
+                list.appendChild(item);
+                return;
+            }
+
+            const createIssueItem = (icon, title, description) => {
+                const item = document.createElement('li');
+                item.className = 'issue-item';
+
+                const iconEl = document.createElement('span');
+                iconEl.className = 'issue-icon';
+                iconEl.textContent = icon;
+                item.appendChild(iconEl);
+
+                const textEl = document.createElement('div');
+                textEl.className = 'issue-text';
+
+                const strong = document.createElement('strong');
+                strong.textContent = title;
+                textEl.appendChild(strong);
+
+                if (description) {
+                    const detail = document.createElement('small');
+                    detail.textContent = description;
+                    textEl.appendChild(detail);
+                }
+
+                item.appendChild(textEl);
+                return item;
+            };
+
+            issues.slice(0, 6).forEach(issue => {
+                const severity = issue.severity || 'Issue';
+                const details = Array.isArray(issue.details) ? issue.details.join(', ') : issue.file || '';
+                const message = issue.message || 'Issue detected';
+                const description = details ? `${message} — ${details}` : message;
+                const category = issue.category ? `: ${issue.category}` : '';
+                const item = createIssueItem(
+                    severityIcon(severity),
+                    `${severity}${category}`.trim(),
+                    description
+                );
+                list.appendChild(item);
+            });
+
+            recommendations.slice(0, 4).forEach(rec => {
+                const detailParts = [];
+                if (rec.reason) detailParts.push(rec.reason);
+                if (Array.isArray(rec.options) && rec.options.length) {
+                    const optionNames = rec.options
+                        .map(option => option.name)
+                        .filter(Boolean)
+                        .join(', ');
+                    if (optionNames) {
+                        detailParts.push(`Options: ${optionNames}`);
+                    }
+                }
+                const description = detailParts.join(' • ');
+                const item = createIssueItem('💡', `Recommendation: ${rec.suggestion || rec.category || 'Improvement'}`, description);
+                list.appendChild(item);
+            });
+        }
+
+        async function fetchJSON(url) {
+            try {
+                const response = await fetch(url, {
+                    headers: { Accept: 'application/json' },
+                    cache: 'no-store',
+                    credentials: 'same-origin'
+                });
+
+                updateCsrfTokenFromResponse(response);
+
+                if (!response.ok) {
+                    if (response.status === 401) {
+                        console.warn('[dashboard] Session expired; reload required.');
+                        return null;
+                    }
+                    if (response.status === 429) {
+                        const message = formatRateLimitMessage(response, 'Request throttled.');
+                        console.warn(`[dashboard] ${message}`);
+                        return null;
+                    }
+                    if (response.status !== 404) {
+                        console.warn(`[dashboard] Failed to load ${url}: ${response.status}`);
+                    }
+                    return null;
+                }
+
+                return await response.json();
             } catch (error) {
-                console.error('Error loading data:', error);
-                showDemoData();
+                console.warn(`[dashboard] Error loading ${url}:`, error);
+                return null;
             }
         }
 
-        function updateDashboard(userData) {
-            // Update project status
-            document.querySelector('#project-name').textContent = userData.account?.email || 'Unknown';
+        async function hydrate() {
+            const [status, tools, report] = await Promise.all([
+                fetchJSON('/api/status'),
+                fetchJSON('/api/tools'),
+                fetchJSON(`/guardian-test-report.json?ts=${Date.now()}`)
+            ]);
 
-            // Update metrics based on real data
-            const statusBadge = document.querySelector('.status-badge');
-            if (userData.usage?.scans > 40) {
-                statusBadge.textContent = 'High Usage';
-                statusBadge.className = 'status-badge status-warning';
+            if (status) {
+                applyStatus(status);
+            }
+
+            if (report) {
+                applySecurity(report);
+                renderIssues(report);
             } else {
-                statusBadge.textContent = 'Active';
-                statusBadge.className = 'status-badge status-good';
+                applySecurity(null);
+                renderIssues(null);
             }
 
-            // TODO: Update other metrics from Firestore data
-        }
-
-        function showDemoData() {
-            // Current demo data is fine for now
-            console.log('Showing demo data');
-        }
-
-        // Load data on page load
-        onAuthStateChanged(auth, (user) => {
-            if (user) {
-                loadRealData();
+            if (tools) {
+                renderTools(tools);
+            } else if (report?.tools) {
+                renderTools(report.tools);
+            } else {
+                renderTools(null);
             }
-        });
+        }
+
+        hydrate();
 
         // Add subtle mouse parallax effect to cards
         document.addEventListener('mousemove', (e) => {

--- a/public/index.html
+++ b/public/index.html
@@ -26,9 +26,9 @@
                     <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
                         <defs>
                             <linearGradient id="cloudGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-                                <stop offset="0%" style="stop-color:#22d3ee;stop-opacity:1" />
-                                <stop offset="50%" style="stop-color:#a78bfa;stop-opacity:1" />
-                                <stop offset="100%" style="stop-color:#8b5cf6;stop-opacity:1" />
+                                <stop offset="0%" stop-color="#22d3ee" stop-opacity="1" />
+                                <stop offset="50%" stop-color="#a78bfa" stop-opacity="1" />
+                                <stop offset="100%" stop-color="#8b5cf6" stop-opacity="1" />
                             </linearGradient>
                         </defs>
                         <path d="M 40 100 Q 40 80 60 80 Q 60 60 80 60 Q 100 40 120 60 Q 140 60 140 80 Q 160 80 160 100 Q 160 120 140 120 L 60 120 Q 40 120 40 100 Z"
@@ -127,15 +127,15 @@
                     <p>Talks to beginners like humans, experts like experts. No condescending "helpful tips".</p>
                 </div>
             </div>
-            <svg style="position:absolute;width:0;height:0">
+            <svg class="hidden-gradient-defs" aria-hidden="true">
                 <defs>
                     <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
-                        <stop offset="0%" style="stop-color:#22d3ee"/>
-                        <stop offset="100%" style="stop-color:#a78bfa"/>
+                        <stop offset="0%" stop-color="#22d3ee"/>
+                        <stop offset="100%" stop-color="#a78bfa"/>
                     </linearGradient>
                     <linearGradient id="grad2" x1="0%" y1="0%" x2="100%" y2="100%">
-                        <stop offset="0%" style="stop-color:#a78bfa"/>
-                        <stop offset="100%" style="stop-color:#8b5cf6"/>
+                        <stop offset="0%" stop-color="#a78bfa"/>
+                        <stop offset="100%" stop-color="#8b5cf6"/>
                     </linearGradient>
                 </defs>
             </svg>
@@ -215,12 +215,12 @@
     <section class="platforms">
         <div class="container">
             <h2 class="section-title">Platform Support</h2>
-            <h3 style="text-align:center; margin-bottom:30px; color:#22d3ee;">v1.0: Deep Validation</h3>
+            <h3 class="timeline-heading timeline-heading--cyan">v1.0: Deep Validation</h3>
             <div class="platform-logos">
                 <div class="platform">Docker</div>
                 <div class="platform">Firebase</div>
             </div>
-            <h3 style="text-align:center; margin-top:40px; margin-bottom:30px; color:#a78bfa;">Upcoming: Detection + Validation</h3>
+            <h3 class="timeline-heading timeline-heading--purple">Upcoming: Detection + Validation</h3>
             <div class="platform-logos">
                 <div class="platform">AWS</div>
                 <div class="platform">Google Cloud</div>
@@ -272,7 +272,7 @@
                     <a href="https://github.com/Domusgpt/nimbus-guardian" class="btn btn-outline">View Source</a>
                 </div>
             </div>
-            <p style="text-align:center; margin-top:30px; color:rgba(255,255,255,0.6);">
+            <p class="footer-note">
                 Copyright © 2025 Paul Phillips - Clear Seas Solutions LLC. All Rights Reserved.
             </p>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -654,6 +654,33 @@ section {
     text-shadow: 0 0 10px var(--glow-purple);
 }
 
+/* Utility Elements */
+.hidden-gradient-defs {
+    position: absolute;
+    width: 0;
+    height: 0;
+}
+
+.timeline-heading {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.timeline-heading--cyan {
+    color: var(--accent-cyan);
+}
+
+.timeline-heading--purple {
+    color: var(--accent-purple);
+    margin-top: 40px;
+}
+
+.footer-note {
+    text-align: center;
+    margin-top: 30px;
+    color: rgba(255, 255, 255, 0.6);
+}
+
 /* Footer */
 .footer {
     background: rgba(0, 0, 0, 0.3);

--- a/simple-dashboard.html
+++ b/simple-dashboard.html
@@ -154,6 +154,36 @@
             text-align: center;
             margin: 20px 0;
         }
+
+        .success-text {
+            text-align: center;
+            margin: 10px 0;
+            font-size: 18px;
+            color: #28a745;
+        }
+
+        .metric-value--success {
+            color: #28a745;
+        }
+
+        .success-banner {
+            margin-top: 20px;
+            padding: 15px;
+            background: #d4edda;
+            border-radius: 8px;
+            color: #155724;
+        }
+
+        .next-steps-list {
+            padding-left: 20px;
+            line-height: 1.8;
+        }
+
+        .next-steps-code {
+            background: #f0f0f0;
+            padding: 2px 8px;
+            border-radius: 4px;
+        }
     </style>
 </head>
 <body>
@@ -248,14 +278,14 @@
                             <strong>HIGH:</strong> .gitignore missing critical patterns
                             <br><small>Missing: .env.*, *.env, dist/, logs/, *.pem, *.key</small>
                         </div>
-                        <button class="btn" onclick="alert('Run: guardian fix')">Fix</button>
+                        <button class="btn" data-fix-message="Run: nimbus fix">Fix</button>
                     </li>
                     <li class="issue-item">
                         <span class="issue-icon">🟡</span>
                         <div class="issue-text">
                             <strong>MEDIUM:</strong> Missing .env.example for team reference
                         </div>
-                        <button class="btn" onclick="alert('Run: guardian fix')">Fix</button>
+                        <button class="btn" data-fix-message="Run: nimbus fix">Fix</button>
                     </li>
                     <li class="issue-item">
                         <span class="issue-icon">💡</span>
@@ -285,7 +315,7 @@
             <div class="card full-width">
                 <h2>✅ Guardian Self-Test Results</h2>
                 <div class="success-icon">🎉</div>
-                <p style="text-align: center; margin: 10px 0; font-size: 18px; color: #28a745;">
+                <p class="success-text">
                     <strong>Guardian Works Perfectly!</strong>
                 </p>
                 <div class="metric">
@@ -302,9 +332,9 @@
                 </div>
                 <div class="metric">
                     <span class="metric-label">Overall Grade</span>
-                    <span class="metric-value" style="color: #28a745;">A-</span>
+                    <span class="metric-value metric-value--success">A-</span>
                 </div>
-                <p style="margin-top: 20px; padding: 15px; background: #d4edda; border-radius: 8px; color: #155724;">
+                <p class="success-banner">
                     <strong>✅ Product is ready for beta users!</strong><br>
                     All core features work correctly. Security scanning, tool detection, and smart recommendations all functioning perfectly.
                 </p>
@@ -313,9 +343,9 @@
             <!-- Next Steps -->
             <div class="card full-width">
                 <h2>🚀 Next Steps</h2>
-                <ol style="padding-left: 20px; line-height: 1.8;">
-                    <li><strong>Run auto-fixes:</strong> <code style="background: #f0f0f0; padding: 2px 8px; border-radius: 4px;">guardian fix</code></li>
-                    <li><strong>Add testing:</strong> <code style="background: #f0f0f0; padding: 2px 8px; border-radius: 4px;">npm install --save-dev jest</code></li>
+                <ol class="next-steps-list">
+                    <li><strong>Run auto-fixes:</strong> <code class="next-steps-code">nimbus fix</code></li>
+                    <li><strong>Add testing:</strong> <code class="next-steps-code">npm install --save-dev jest</code></li>
                     <li><strong>Setup CI/CD:</strong> Create .github/workflows/test.yml</li>
                     <li><strong>Test with real users:</strong> Share with 20 developers for beta testing</li>
                     <li><strong>Launch:</strong> Product Hunt, Reddit, Dev.to</li>
@@ -329,6 +359,15 @@
         console.log('Guardian Dashboard loaded');
         console.log('This is a static demo of the test results');
         console.log('For live data, run: node dashboard-server.js (after fixing the async issue)');
+
+        document.querySelectorAll('[data-fix-message]').forEach((button) => {
+            button.addEventListener('click', () => {
+                const message = button.getAttribute('data-fix-message');
+                if (message) {
+                    alert(message);
+                }
+            });
+        });
     </script>
 </body>
 </html>

--- a/test-run.js
+++ b/test-run.js
@@ -187,13 +187,13 @@ async function runTest() {
 
     console.log('\n💡 Next Steps:');
     if (securityResults.issues.filter(i => i.autoFixable).length > 0) {
-        console.log('   1. Run: guardian fix (to auto-fix issues)');
+        console.log('   1. Run: nimbus fix (to auto-fix issues)');
     }
     if (toolResults.missing.length > 0) {
         console.log('   2. Install missing tools (see above)');
     }
-    console.log('   3. Launch dashboard: guardian dashboard');
-    console.log('   4. Try AI chat: guardian chat\n');
+    console.log('   3. Launch dashboard: nimbus dashboard');
+    console.log('   4. Try AI chat: nimbus chat\n');
 
     // Generate report file
     const report = {

--- a/tests/config-service.test.js
+++ b/tests/config-service.test.js
@@ -1,0 +1,93 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('os');
+const path = require('path');
+const fs = require('fs-extra');
+
+const {
+    loadConfig,
+    saveConfig,
+    getConfigPaths
+} = require('../lib/config-service');
+
+async function createTempProject(t) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'guardian-config-'));
+    t.after(async () => {
+        await fs.remove(dir);
+    });
+    return dir;
+}
+
+test('loadConfig creates default config when missing', async (t) => {
+    const projectDir = await createTempProject(t);
+    const config = await loadConfig(projectDir, { createIfMissing: true });
+
+    assert.equal(config.experienceLevel, 'intermediate');
+    assert.ok(config.projectName);
+
+    const { configPath } = getConfigPaths(projectDir);
+    const persisted = await fs.readJson(configPath);
+    assert.equal(persisted.experienceLevel, 'intermediate');
+    assert.equal(persisted.projectName, config.projectName);
+});
+
+test('saveConfig strips secrets and normalizes experience', async (t) => {
+    const projectDir = await createTempProject(t);
+    await saveConfig(projectDir, {
+        experienceLevel: 'ADVANCED',
+        claudeApiKey: 'secret-1',
+        geminiApiKey: 'secret-2'
+    });
+
+    const { configPath } = getConfigPaths(projectDir);
+    const persisted = await fs.readJson(configPath);
+    assert.equal(persisted.experienceLevel, 'advanced');
+    assert.ok(!Object.prototype.hasOwnProperty.call(persisted, 'claudeApiKey'));
+    assert.ok(!Object.prototype.hasOwnProperty.call(persisted, 'geminiApiKey'));
+});
+
+test('loadConfig hydrates API keys from .env and exposes metadata', async (t) => {
+    const projectDir = await createTempProject(t);
+    const { configDir, envPath } = getConfigPaths(projectDir);
+    await fs.ensureDir(configDir);
+    await fs.writeFile(envPath, 'CLAUDE_API_KEY=abc\nGEMINI_API_KEY=def\n');
+
+    const config = await loadConfig(projectDir, { createIfMissing: true });
+
+    assert.equal(config.claudeApiKey, 'abc');
+    assert.equal(config.geminiApiKey, 'def');
+    assert.ok(config.__meta);
+    assert.deepEqual(config.__meta.warnings, []);
+});
+
+test('loadConfig recovers from corrupted JSON and informs caller', async (t) => {
+    const projectDir = await createTempProject(t);
+    const { configDir, configPath } = getConfigPaths(projectDir);
+    await fs.ensureDir(configDir);
+    await fs.writeFile(configPath, '{invalid-json');
+
+    const config = await loadConfig(projectDir, { createIfMissing: true });
+
+    assert.equal(config.experienceLevel, 'intermediate');
+    assert.ok(config.__meta);
+    assert.equal(config.__meta.warnings.length, 1);
+    assert.match(config.__meta.warnings[0], /Recovered from corrupted/);
+
+    const backups = await fs.readdir(configDir);
+    const backupFile = backups.find((name) => name.startsWith('config.json.corrupted-'));
+    assert.ok(backupFile, 'should create corrupted backup file');
+});
+
+test('loadConfig migrates legacy experience property', async (t) => {
+    const projectDir = await createTempProject(t);
+    const { configDir, configPath } = getConfigPaths(projectDir);
+    await fs.ensureDir(configDir);
+    await fs.writeJson(configPath, { experience: 'beginner' });
+
+    const config = await loadConfig(projectDir);
+
+    assert.equal(config.experienceLevel, 'beginner');
+    const persisted = await fs.readJson(configPath);
+    assert.equal(persisted.experienceLevel, 'beginner');
+    assert.ok(!Object.prototype.hasOwnProperty.call(persisted, 'experience'));
+});

--- a/tests/rate-limiter.test.js
+++ b/tests/rate-limiter.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const RateLimiter = require('../lib/rate-limiter');
+
+test('RateLimiter allows requests within the window', () => {
+    let now = 0;
+    const limiter = new RateLimiter({ windowMs: 1000, max: 3, now: () => now });
+
+    const first = limiter.consume('user');
+    assert.deepEqual(first.allowed, true);
+    assert.equal(first.remaining, 2);
+
+    const second = limiter.consume('user');
+    assert.equal(second.allowed, true);
+    assert.equal(second.remaining, 1);
+
+    const third = limiter.consume('user');
+    assert.equal(third.allowed, true);
+    assert.equal(third.remaining, 0);
+});
+
+test('RateLimiter blocks when limit exceeded and resets after window', () => {
+    let now = 0;
+    const limiter = new RateLimiter({ windowMs: 1000, max: 2, now: () => now });
+
+    limiter.consume('session');
+    limiter.consume('session');
+
+    const blocked = limiter.consume('session');
+    assert.equal(blocked.allowed, false);
+    assert.equal(blocked.remaining, 0);
+    assert.equal(blocked.retryAfterMs, 1000);
+
+    now = 1001;
+    const afterWindow = limiter.consume('session');
+    assert.equal(afterWindow.allowed, true);
+    assert.equal(afterWindow.remaining, 1);
+});
+
+test('RateLimiter handles weights larger than remaining quota', () => {
+    let now = 0;
+    const limiter = new RateLimiter({ windowMs: 2000, max: 5, now: () => now });
+
+    const allowed = limiter.consume('key', 3);
+    assert.equal(allowed.allowed, true);
+    assert.equal(allowed.remaining, 2);
+
+    const blocked = limiter.consume('key', 3);
+    assert.equal(blocked.allowed, false);
+    assert.equal(blocked.remaining, 2);
+    assert.ok(blocked.retryAfterMs > 0);
+
+    now = 3000;
+    const reset = limiter.consume('key', 2);
+    assert.equal(reset.allowed, true);
+    assert.equal(reset.remaining, 3);
+});
+
+test('RateLimiter rejects invalid parameters', () => {
+    const limiter = new RateLimiter({ windowMs: 1000, max: 1 });
+
+    assert.throws(() => limiter.consume('', 1), /key is required/);
+    assert.throws(() => limiter.consume('k', 0), /weight must be a positive number/);
+});

--- a/tests/session-manager.test.js
+++ b/tests/session-manager.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const SessionManager = require('../lib/session-manager');
+
+test('createSession returns a session with id and csrf token', () => {
+    const manager = new SessionManager({ ttlMs: 1000 * 60, cleanupIntervalMs: 0 });
+    const session = manager.createSession();
+
+    assert.ok(session);
+    assert.ok(typeof session.id === 'string' && session.id.length > 0);
+    assert.ok(typeof session.csrfToken === 'string' && session.csrfToken.length > 0);
+    assert.equal(manager.getSession(session.id), session);
+});
+
+test('sessions expire after ttl elapses', () => {
+    let now = 0;
+    const manager = new SessionManager({
+        ttlMs: 100,
+        cleanupIntervalMs: 0,
+        now: () => now
+    });
+
+    const session = manager.createSession();
+    assert.ok(manager.getSession(session.id));
+
+    now = 150;
+    assert.equal(manager.getSession(session.id), null);
+});
+
+test('touchSession refreshes timestamps and rotates csrf when requested', () => {
+    let now = 1000;
+    const tokens = ['initial-token', 'rotated-token'];
+    const manager = new SessionManager({
+        ttlMs: 1000,
+        cleanupIntervalMs: 0,
+        now: () => now,
+        tokenGenerator: () => tokens.shift() || 'exhausted'
+    });
+
+    const session = manager.createSession();
+    assert.equal(session.csrfToken, 'initial-token');
+
+    now = 1500;
+    const touched = manager.touchSession(session.id, { rotateCsrf: true });
+    assert.ok(touched);
+    assert.equal(touched.csrfToken, 'rotated-token');
+    assert.equal(manager.getSession(session.id).csrfToken, 'rotated-token');
+    assert.equal(touched.lastSeen, now);
+});

--- a/tool-detector.js
+++ b/tool-detector.js
@@ -19,6 +19,16 @@ class ToolDetector {
         this.recommendations = [];
     }
 
+    normalizeId(value) {
+        return value
+            ? value
+                .toString()
+                .trim()
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')
+            : null;
+    }
+
     async analyze() {
         console.log('🔍 Analyzing project structure and dependencies...\n');
 
@@ -383,6 +393,7 @@ class ToolDetector {
             const dockerInstalled = this.isCommandAvailable('docker');
             if (!dockerInstalled) {
                 this.missingTools.push({
+                    id: this.normalizeId('docker'),
                     category: 'containerization',
                     name: 'docker',
                     reason: 'Docker files detected but Docker not installed',
@@ -402,6 +413,7 @@ class ToolDetector {
             const kubectlInstalled = this.isCommandAvailable('kubectl');
             if (!kubectlInstalled) {
                 this.missingTools.push({
+                    id: this.normalizeId('kubectl'),
                     category: 'orchestration',
                     name: 'kubectl',
                     reason: 'Kubernetes config detected but kubectl not installed',
@@ -521,9 +533,11 @@ class ToolDetector {
 
             if (!isInstalled) {
                 this.missingTools.push({
+                    id: this.normalizeId(cliInfo.name),
                     category: 'cli',
                     provider,
                     cli: cliInfo.name,
+                    name: cliInfo.name,
                     command: cliInfo.command,
                     install: cliInfo.install,
                     docs: cliInfo.docs,
@@ -558,6 +572,7 @@ class ToolDetector {
                 });
             } else if (!tool.optional) {
                 this.missingTools.push({
+                    id: this.normalizeId(tool.name),
                     category: tool.category,
                     name: tool.name,
                     reason: `${tool.name} is required but not installed`

--- a/validators/docker-validator.js
+++ b/validators/docker-validator.js
@@ -108,11 +108,13 @@ class DockerValidator {
     }
 
     async checkSecrets(lines) {
+        const secretIndicators = ['PASSWORD', 'API_KEY', 'SECRET'];
+
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i].trim();
 
             // Check for hardcoded secrets
-            if (line.includes('PASSWORD=') || line.includes('API_KEY=') || line.includes('SECRET=')) {
+            if (secretIndicators.some(indicator => line.includes(`${indicator}=`))) {
                 this.issues.push({
                     id: 'docker-hardcoded-secret',
                     severity: 'CRITICAL',


### PR DESCRIPTION
## Summary
- add an in-memory rate limiter utility with focused unit tests
- enforce per-action limits on dashboard API endpoints and return Retry-After hints when throttled
- update the bundled dashboards to read throttle headers and surface user-friendly guidance when requests are limited

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2f51ec50c83299334ba86a6381201